### PR TITLE
fix apppath for AppImage

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -38,7 +38,7 @@ function getPear() {
 
 function getAppPath() {
   if (!app.isPackaged) return null
-  if (isLinux) return process.env.APPIMAGE
+  if (isLinux && process.env.APPIMAGE) return process.env.APPIMAGE
   return path.join(process.resourcesPath, '..', '..')
 }
 


### PR DESCRIPTION
```shell
npm run make
./HelloPear-1.0.0-x64.AppImage --appimage-extract 
```

the created `./squashfs-root/AppRun` has
```shell
if [ -z "$APPIMAGE" ] ; then
  APPIMAGE="$APPDIR/AppRun"
fi
```