### PR TITLE
Use quit over exit for a cleaner shutdown after OTA update

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -168,7 +168,7 @@ ipcMain.handle('app:restart', () => {
   } else {
     app.relaunch()
   }
-  app.exit(0)
+  app.quit()
 })
 
 function handleDeepLink(url) {


### PR DESCRIPTION
After an OTA update `app.exit(0)` is called which exits immediately. This means we do not get the `before-quit` event which is used to destroy bare workers. Looking into it `worker.destroy()` is just calling `destroy` on the stream so it is also not particularly graceful but we should treat the restart caused by an OTA update in the same way as when a user closes the app.

I have tested this change locally by going through the update process.