### PR TITLE
Strip macOS locales to minimize build

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ To enable updates for testing update flow in local development use
 npm start -- --updates
 ```
 
+### Packaging
+
+By default macOS packaging keeps only the Electron `en` locale to reduce bundle size. To keep all locales set `"electronLocales": "all"` in `package.json` or package with `ELECTRON_LOCALES=all`. To keep a subset, set `"electronLocales": ["en", "fr"]`.
+
 ## Architecture
 
 The application architecture is tightly scoped to handling P2P OTA Updates, running embedded [Bare][bare] workers and facilitating [Peer-to-Peer Deployment](#deployments) flows.

--- a/forge.config.js
+++ b/forge.config.js
@@ -4,6 +4,35 @@ const pkg = require('./package.json')
 const appName = pkg.productName ?? pkg.name
 const { isWindows } = require('which-runtime')
 
+function getElectronLocales() {
+  if (process.env.ELECTRON_LOCALES === 'all') return null
+  if (pkg.electronLocales === 'all') return null
+  if (Array.isArray(pkg.electronLocales)) return new Set(pkg.electronLocales)
+  return new Set(['en'])
+}
+
+function pruneElectronLocales(appPath) {
+  const locales = getElectronLocales()
+  if (locales === null) return
+
+  const resourcesDir = path.join(
+    appPath,
+    'Contents',
+    'Frameworks',
+    'Electron Framework.framework',
+    'Versions',
+    'A',
+    'Resources'
+  )
+
+  for (const entry of fs.readdirSync(resourcesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !entry.name.endsWith('.lproj')) continue
+    const locale = entry.name.slice(0, -'.lproj'.length)
+    if (locales.has(locale)) continue
+    fs.rmSync(path.join(resourcesDir, entry.name), { recursive: true, force: true })
+  }
+}
+
 function getWindowsKitVersion() {
   const programFiles = process.env['PROGRAMFILES(X86)'] || process.env.PROGRAMFILES
   if (!programFiles) return undefined
@@ -82,6 +111,12 @@ module.exports = {
       const msixVersion = pkg.version.replace(/^(\d+\.\d+\.\d+)$/, '$1.0')
       const xml = fs.readFileSync(manifest, 'utf-8')
       fs.writeFileSync(manifest, xml.replace(/Version="[^"]*"/, `Version="${msixVersion}"`))
+    },
+    postPackage: async (forgeConfig, { outputPaths, platform }) => {
+      if (platform !== 'darwin') return
+      for (const outputPath of outputPaths) {
+        pruneElectronLocales(path.join(outputPath, `${appName}.app`))
+      }
     },
     postMake: async (forgeConfig, results) => {
       for (const result of results) {


### PR DESCRIPTION
Strips some MBs from the bundle sizes.

Keeps only `en` by default with option to opt in to `all` or list of languages.

```
 Saved:

 - app bundle: 350 MB -> 304 MB
 - on-disk savings: ~46 MB
 - zipped bundle: 132.03 MB -> 120.59 MB
 - compressed savings: ~11.44 MB
```