### PR TITLE
Linux AppImage fixes

### DIFF
--- a/build/AppRun
+++ b/build/AppRun
@@ -31,7 +31,7 @@ export LD_LIBRARY_PATH="${APPDIR}/usr/lib:${LD_LIBRARY_PATH}"
 export XDG_DATA_DIRS="${APPDIR}"/usr/share/:"${XDG_DATA_DIRS}":/usr/share/gnome/:/usr/local/share/:/usr/share/
 export GSETTINGS_SCHEMA_DIR="${APPDIR}/usr/share/glib-2.0/schemas:${GSETTINGS_SCHEMA_DIR}"
 
-BIN="$APPDIR/Keet"
+BIN="$APPDIR/HelloPear"
 
 if [ -z "$APPIMAGE_EXIT_AFTER_INSTALL" ] ; then
   trap atexit EXIT

--- a/scripts/build-app-image.sh
+++ b/scripts/build-app-image.sh
@@ -96,7 +96,7 @@ CONFIG_JSON=$(jq -n \
   }'
 )
 
-CUSTOM_APPRUN="$ROOT/scripts/linux/AppRun"
+CUSTOM_APPRUN="$ROOT/build/AppRun"
 
 if [ -f "$CUSTOM_APPRUN" ]; then
   echo "→ Using custom AppRun $CUSTOM_APPRUN"

--- a/scripts/build-app-image.sh
+++ b/scripts/build-app-image.sh
@@ -4,15 +4,15 @@ set -euo pipefail
 ROOT="$(pwd)"
 PKG="$ROOT/package.json"
 
-[ -f "$PKG" ] || { echo "package.json not found in $ROOT"; exit 1; }
-command -v jq >/dev/null 2>&1 || { echo "jq is required"; exit 1; }
+[ -f "$PKG" ] || { echo "ERROR: package.json not found in $ROOT"; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required"; exit 1; }
 
 # Detect architecture dynamically
 UNAME_ARCH=$(uname -m)
 case "$UNAME_ARCH" in
   x86_64) ARCH="x64" ;;
   aarch64 | arm64) ARCH="arm64" ;;
-  *) echo "Unsupported architecture: $UNAME_ARCH"; exit 1 ;;
+  *) echo "ERROR: Unsupported architecture: $UNAME_ARCH"; exit 1 ;;
 esac
 
 APP_BUILDER="$(node -e "


### PR DESCRIPTION
1. Replace hardcoded "Keet" for $productName
3. CUSTOM_APPRUN: while testing uncovered a bug with stale path `"$ROOT/scripts/linux/AppRun"` (effectively dead code), now uses the correct path, because it didn't exist it was skipping copy of the custom AppRun and went with app-builder to generate
4. Improved error logs with ERROR label, to highlight lines like "jq is required"

---

this PR

```bash
→ App: HelloPear
→ Version: 1.0.0
→ Description: 
→ Using app dir: /home/kali/Temp/1/hello-pear-electron/out/HelloPear-linux-arm64

*new*
→ Using custom AppRun /home/kali/Temp/1/hello-pear-electron/build/AppRun

→ Running app-builder with the following command:
/home/kali/Temp/1/hello-pear-electron/node_modules/app-builder-bin/linux/arm64/app-builder appimage --stage /home/kali/Temp/1/hello-pear-electron/out/make/__appImage-arm64 --arch arm64 --output /home/kali/Temp/1/hello-pear-electron/out/make/HelloPear.AppImage --app /home/kali/Temp/1/hello-pear-electron/out/HelloPear-linux-arm64 --configuration '{
  "productName": "HelloPear",
  "productFilename": "HelloPear",
  "desktopEntry": "[Desktop Entry]\nName=HelloPear\nExec=HelloPear\nTerminal=false\nType=Application\nIcon=HelloPear\nStartupWMClass=undefined\nX-AppImage-Version=1.0.0\nComment=\nCategories=Utility",
  "executableName": "HelloPear",
  "icons": [

```

`main` branch

```bash
→ App: HelloPear
→ Version: 1.0.0
→ Description: 
→ Using app dir: /home/kali/Temp/1/hello-pear-electron/out/HelloPear-linux-arm64

→ Running app-builder with the following command:
/home/kali/Temp/1/hello-pear-electron/node_modules/app-builder-bin/linux/arm64/app-builder appimage --stage /home/kali/Temp/1/hello-pear-electron/out/make/__appImage-arm64 --arch arm64 --output /home/kali/Temp/1/hello-pear-electron/out/make/HelloPear.AppImage --app /home/kali/Temp/1/hello-pear-electron/out/HelloPear-linux-arm64 --configuration '{
  "productName": "HelloPear",
  "productFilename": "HelloPear",
  "desktopEntry": "[Desktop Entry]\nName=HelloPear\nExec=HelloPear\nTerminal=false\nType=Application\nIcon=HelloPear\nStartupWMClass=undefined\nX-AppImage-Version=1.0.0\nComment=\nCategories=Utility",
  "executableName": "HelloPear",
  "icons": [
```
