### PR TITLE
Linux AppImage fixes

### DIFF
--- a/build/AppRun
+++ b/build/AppRun
@@ -31,7 +31,7 @@ export LD_LIBRARY_PATH="${APPDIR}/usr/lib:${LD_LIBRARY_PATH}"
 export XDG_DATA_DIRS="${APPDIR}"/usr/share/:"${XDG_DATA_DIRS}":/usr/share/gnome/:/usr/local/share/:/usr/share/
 export GSETTINGS_SCHEMA_DIR="${APPDIR}/usr/share/glib-2.0/schemas:${GSETTINGS_SCHEMA_DIR}"
 
-BIN="$APPDIR/Keet"
+BIN="$APPDIR/{{.ExecutableName}}"
 
 if [ -z "$APPIMAGE_EXIT_AFTER_INSTALL" ] ; then
   trap atexit EXIT

--- a/electron/main.js
+++ b/electron/main.js
@@ -20,7 +20,8 @@ const appName = productName ?? name
 const cmd = command(
   appName,
   flag('--storage <dir>', 'pass custom storage to pear-runtime'),
-  flag('--no-updates', 'start without OTA updates')
+  flag('--no-updates', 'start without OTA updates'),
+  flag('--no-sandbox', 'start without Chromium sandbox')
 )
 
 cmd.parse(app.isPackaged ? process.argv.slice(1) : process.argv.slice(2))

--- a/electron/main.js
+++ b/electron/main.js
@@ -21,7 +21,7 @@ const cmd = command(
   appName,
   flag('--storage <dir>', 'pass custom storage to pear-runtime'),
   flag('--no-updates', 'start without OTA updates'),
-  flag('--no-sandbox', 'start without Chromium sandbox')
+  flag('--no-sandbox', 'start without Chromium sandbox').hide()
 )
 
 cmd.parse(app.isPackaged ? process.argv.slice(1) : process.argv.slice(2))

--- a/scripts/build-app-image.sh
+++ b/scripts/build-app-image.sh
@@ -96,7 +96,7 @@ CONFIG_JSON=$(jq -n \
   }'
 )
 
-CUSTOM_APPRUN="$ROOT/scripts/linux/AppRun"
+CUSTOM_APPRUN="$ROOT/build/AppRun"
 
 if [ -f "$CUSTOM_APPRUN" ]; then
   echo "→ Using custom AppRun $CUSTOM_APPRUN"

--- a/scripts/build-app-image.sh
+++ b/scripts/build-app-image.sh
@@ -100,8 +100,8 @@ CUSTOM_APPRUN="$ROOT/build/AppRun"
 
 if [ -f "$CUSTOM_APPRUN" ]; then
   echo "→ Using custom AppRun $CUSTOM_APPRUN"
-  cp "$CUSTOM_APPRUN" "$STAGE_DIR/AppRun"
-  chmod +x "$STAGE_DIR/AppRun"
+  sed "s/{{.ExecutableName}}/$APP_NAME/g" "$CUSTOM_APPRUN" > "$APP_DIR/AppRun"
+  chmod +x "$APP_DIR/AppRun"
 fi
 
 echo "→ Running app-builder with the following command:"


### PR DESCRIPTION
* use `productName` for binary name instead of hardcoded ones

```bash
./out/make/HelloPear.AppImage --appimage-extract
squashfs-root/HelloPear
squashfs-root/HelloPear.desktop
```

---


* Fix: now this execution path is reached

```bash
→ Using custom AppRun ./hello-pear-electron/build/AppRun
```

---

* Fix: preserve custom AppRun as final AppImage including `--no-sandbox`

PR:

```bash
cat squashfs-root/AppRun
atexit()
{
  if [ $isEulaAccepted == 1 ] ; then
    if [ $NUMBER_OF_ARGS -eq 0 ] ; then
      exec "$BIN" --no-sandbox
    else
      exec "$BIN" --no-sandbox "${args[@]}"
    fi
  fi
}
```

Before:

```bash
cat squashfs-root/AppRun
atexit()
{
  if [ $isEulaAccepted == 1 ] ; then
    if [ $NUMBER_OF_ARGS -eq 0 ] ; then
      exec "$BIN"
    else
      exec "$BIN" "${args[@]}"
    fi
  fi
}
```

---

app works & confirmed via `ps aux` runs as `HelloPear --no-sandbox`

<img width="817" height="638" alt="image" src="https://github.com/user-attachments/assets/163a4694-6aa7-44c2-afcb-a325ef9dfd24" />

