### PR TITLE
GitHub Action `build-release` for CI builds

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,118 @@
+name: Build Release
+
+on:
+  workflow_call:
+    inputs:
+      upgrade-key:
+        type: string
+        default: ''
+
+  workflow_dispatch:
+    inputs:
+      upgrade-key:
+        description: Value for package.json upgrade field
+        required: false
+
+jobs:
+  build-linux-x64:
+    timeout-minutes: 20
+    permissions:
+      contents: write # to upload artifacts
+      packages: read
+    runs-on: ubuntu-latest
+    environment: release
+    outputs:
+      artifact-links: ${{ steps.build.outputs.artifact-links }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: holepunchto/actions/make-pear-app@v1
+        id: build
+        with:
+          channel: production
+          upgrade_key: ${{ inputs['upgrade-key'] }}
+
+  build-linux-arm:
+    timeout-minutes: 20
+    permissions:
+      contents: write # to upload artifacts
+      packages: read
+    runs-on: ubuntu-24.04-arm
+    environment: release
+    outputs:
+      artifact-links: ${{ steps.build.outputs.artifact-links }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: holepunchto/actions/make-pear-app@v1
+        id: build
+        with:
+          channel: production
+          upgrade_key: ${{ inputs['upgrade-key'] }}
+
+  build-macos:
+    timeout-minutes: 20
+    permissions:
+      contents: write # to upload artifacts
+      packages: read
+    runs-on: macos-latest
+    environment: release
+    outputs:
+      artifact-links: ${{ steps.build.outputs.artifact-links }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: holepunchto/actions/make-pear-app@v1
+        id: build
+        with:
+          channel: production
+          upgrade_key: ${{ inputs['upgrade-key'] }}
+          macos_certificate_base64: ${{ secrets.CERTIFICATE_P12 }}
+          macos_p12_password: ${{ secrets.CERTIFICATE_PASSWORD }}
+          macos_codesign_identity: ${{ secrets.MAC_CODESIGN_IDENTITY }}
+          macos_notarization_method: apple_id_password
+          macos_apple_id: ${{ secrets.APPLE_ID }}
+          macos_apple_password: ${{ secrets.APPLE_PASSWORD }}
+          macos_apple_team_id: ${{ secrets.APPLE_TEAM_ID }}
+
+  build-macos-x64:
+    timeout-minutes: 20
+    permissions:
+      contents: write # to upload artifacts
+      packages: read
+    runs-on: macos-26-intel
+    environment: release
+    outputs:
+      artifact-links: ${{ steps.build.outputs.artifact-links }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: holepunchto/actions/make-pear-app@v1
+        id: build
+        with:
+          channel: production
+          upgrade_key: ${{ inputs['upgrade-key'] }}
+          macos_certificate_base64: ${{ secrets.CERTIFICATE_P12 }}
+          macos_p12_password: ${{ secrets.CERTIFICATE_PASSWORD }}
+          macos_codesign_identity: ${{ secrets.MAC_CODESIGN_IDENTITY }}
+          macos_notarization_method: apple_id_password
+          macos_apple_id: ${{ secrets.APPLE_ID }}
+          macos_apple_password: ${{ secrets.APPLE_PASSWORD }}
+          macos_apple_team_id: ${{ secrets.APPLE_TEAM_ID }}
+
+  build-win32:
+    timeout-minutes: 20
+    permissions:
+      contents: write # to upload artifacts
+      packages: read
+    runs-on: windows-latest
+    environment: release
+    outputs:
+      artifact-links: ${{ steps.build.outputs.artifact-links }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: holepunchto/actions/make-pear-app@v1
+        id: build
+        with:
+          channel: production
+          upgrade_key: ${{ inputs['upgrade-key'] }}
+          windows_signing_method: windows_cert_pfx
+          windows_cert_pfx_base64: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
+          windows_cert_password: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -115,4 +115,3 @@ jobs:
           windows_signing_method: windows_cert_pfx
           windows_cert_pfx_base64: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
           windows_cert_password: ${{ secrets.WINDOWS_CERT_PASSWORD }}
-

--- a/README.md
+++ b/README.md
@@ -996,16 +996,16 @@ The `upgrade` field can be set to one link only. Share alternative builds intern
 
 Create a GitHub environment (Settings -> Environments) named `release`. Run the `Build Release` workflow to build in CI. This workflow requires these secrets for signed builds:
 
-| Secret                    | Platform | Notes                                                       |
-| ------------------------- | -------- | ----------------------------------------------------------- |
-| `CERTIFICATE_P12`         | `darwin` | Base64 export of Developer ID Application `.p12`            |
-| `CERTIFICATE_PASSWORD`    | `darwin` | Password used to export the `.p12`                          |
-| `MAC_CODESIGN_IDENTITY`   | `darwin` | Developer ID identity from `security find-identity`         |
-| `APPLE_ID`                | `darwin` | Email used for Apple Developer                              |
-| `APPLE_PASSWORD`          | `darwin` | App-specific password (not the account password)            |
-| `APPLE_TEAM_ID`           | `darwin` | Membership details at <https://developer.apple.com/account> |
-| `WINDOWS_CERT_PFX_BASE64` | `win32`  | Base64 export of Windows `.pfx`                             |
-| `WINDOWS_CERT_PASSWORD`   | `win32`  | Password for the Windows `.pfx`                             |
+| Secret                    | Platform | Notes                                                                             |
+| ------------------------- | -------- | --------------------------------------------------------------------------------- |
+| `CERTIFICATE_P12`         | `darwin` | Base64 export of Developer ID Application `.p12`                                  |
+| `CERTIFICATE_PASSWORD`    | `darwin` | Password used to export the `.p12`                                                |
+| `MAC_CODESIGN_IDENTITY`   | `darwin` | Developer ID Application identity, e.g. `Developer ID Application: Name (TEAMID)` |
+| `APPLE_ID`                | `darwin` | Email used for Apple Developer                                                    |
+| `APPLE_PASSWORD`          | `darwin` | App-specific password (not the account password)                                  |
+| `APPLE_TEAM_ID`           | `darwin` | Membership details at <https://developer.apple.com/account>                       |
+| `WINDOWS_CERT_PFX_BASE64` | `win32`  | Base64 export of Windows `.pfx`                                                   |
+| `WINDOWS_CERT_PASSWORD`   | `win32`  | Password for the Windows `.pfx`                                                   |
 
 - macOS signing requires an [Apple Developer Program](https://developer.apple.com) membership.
 - Windows certificate 'subject' must match the `Publisher` in [AppxManifest.xml](build/AppxManifest.xml).

--- a/README.md
+++ b/README.md
@@ -996,16 +996,16 @@ The `upgrade` field can be set to one link only. Share alternative builds intern
 
 Create a GitHub environment (Settings -> Environments) named `release`. Run the `Build Release` workflow to build in CI. This workflow requires these secrets for signed builds:
 
-| Secret                    | Platform | Notes                                                                             |
-| ------------------------- | -------- | --------------------------------------------------------------------------------- |
-| `CERTIFICATE_P12`         | `darwin` | Base64 export of Developer ID Application `.p12`                                  |
-| `CERTIFICATE_PASSWORD`    | `darwin` | Password used to export the `.p12`                                                |
-| `MAC_CODESIGN_IDENTITY`   | `darwin` | Developer ID Application identity, e.g. `Developer ID Application: Name (TEAMID)` |
-| `APPLE_ID`                | `darwin` | Email used for Apple Developer                                                    |
-| `APPLE_PASSWORD`          | `darwin` | App-specific password (not the account password)                                  |
-| `APPLE_TEAM_ID`           | `darwin` | Membership details at <https://developer.apple.com/account>                       |
-| `WINDOWS_CERT_PFX_BASE64` | `win32`  | Base64 export of Windows `.pfx`                                                   |
-| `WINDOWS_CERT_PASSWORD`   | `win32`  | Password for the Windows `.pfx`                                                   |
+| Secret                    | Platform | Notes                                                       |
+| ------------------------- | -------- | ----------------------------------------------------------- |
+| `CERTIFICATE_P12`         | `darwin` | Base64 export of Developer ID Application `.p12`            |
+| `CERTIFICATE_PASSWORD`    | `darwin` | Password used to export the `.p12`                          |
+| `MAC_CODESIGN_IDENTITY`   | `darwin` | e.g. `Developer ID Application: Name (TEAMID)`              |
+| `APPLE_ID`                | `darwin` | Apple Developer account email                               |
+| `APPLE_PASSWORD`          | `darwin` | App-specific password (not the account password)            |
+| `APPLE_TEAM_ID`           | `darwin` | Membership details at <https://developer.apple.com/account> |
+| `WINDOWS_CERT_PFX_BASE64` | `win32`  | Base64 export of Windows `.pfx`                             |
+| `WINDOWS_CERT_PASSWORD`   | `win32`  | Password for the Windows `.pfx`                             |
 
 - macOS signing requires an [Apple Developer Program](https://developer.apple.com) membership.
 - Windows certificate 'subject' must match the `Publisher` in [AppxManifest.xml](build/AppxManifest.xml).

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ End-to-end boilerplate for embedding [pear-runtime][pear-runtime] into [Electron
     - [Release Lines](#release-lines)
     - [Release Line Builds](#release-line-builds)
     - [Custom Builds](#custom-builds)
+- [CI Configuration](#ci-configuration)
 - [Scripts](#scripts)
 - [Troubleshooting](#troubleshooting)
 
@@ -990,6 +991,25 @@ The `upgrade` field can be set to one link only. Share alternative builds intern
 - [3. Make Distributables](#make-distributables)
 - [4. Build Deployment Directory](#build-deploy-directory)
 - [5. Stage](#stage)
+
+## CI Configuration <a name="ci-configuration"></a>
+
+Create a GitHub environment (Settings -> Environments) named `release`. Run the `Build Release` workflow to build in CI. This workflow requires these secrets for signed builds:
+
+| Secret                    | Platform | Notes                                                       |
+| ------------------------- | -------- | ----------------------------------------------------------- |
+| `CERTIFICATE_P12`         | `darwin` | Base64 export of Developer ID Application `.p12`            |
+| `CERTIFICATE_PASSWORD`    | `darwin` | Password used to export the `.p12`                          |
+| `MAC_CODESIGN_IDENTITY`   | `darwin` | Developer ID identity from `security find-identity`         |
+| `APPLE_ID`                | `darwin` | Email used for Apple Developer                              |
+| `APPLE_PASSWORD`          | `darwin` | App-specific password (not the account password)            |
+| `APPLE_TEAM_ID`           | `darwin` | Membership details at <https://developer.apple.com/account> |
+| `WINDOWS_CERT_PFX_BASE64` | `win32`  | Base64 export of Windows `.pfx`                             |
+| `WINDOWS_CERT_PASSWORD`   | `win32`  | Password for the Windows `.pfx`                             |
+
+- macOS signing requires an [Apple Developer Program](https://developer.apple.com) membership.
+- Windows certificate 'subject' must match the `Publisher` in [AppxManifest.xml](build/AppxManifest.xml).
+- Linux builds are not signed, no configuration needed.
 
 ## Scripts <a name="scripts"></a>
 

--- a/forge.config.js
+++ b/forge.config.js
@@ -2,7 +2,6 @@ const fs = require('fs')
 const path = require('path')
 const pkg = require('./package.json')
 const appName = pkg.productName ?? pkg.name
-const { isWindows } = require('which-runtime')
 
 function getWindowsKitVersion() {
   const programFiles = process.env['PROGRAMFILES(X86)'] || process.env.PROGRAMFILES
@@ -40,9 +39,8 @@ if (process.env.MAC_CODESIGN_IDENTITY) {
       })
     },
     osxNotarize: {
-      appleId: process.env.APPLE_ID,
-      appleIdPassword: process.env.APPLE_PASSWORD,
-      teamId: process.env.APPLE_TEAM_ID
+      tool: 'notarytool',
+      keychainProfile: process.env.KEYCHAIN_PROFILE
     }
   }
 }
@@ -62,11 +60,10 @@ module.exports = {
       config: {
         appManifest: path.join(__dirname, 'build', 'AppxManifest.xml'),
         windowsKitVersion: getWindowsKitVersion(),
-        ...(process.env.WINDOWS_CERTIFICATE_FILE
+        ...(process.env.WINDOWS_SIGN_HOOK
           ? {
               windowsSignOptions: {
-                certificateFile: process.env.WINDOWS_CERTIFICATE_FILE,
-                certificatePassword: process.env.WINDOWS_CERTIFICATE_PASSWORD
+                hookModulePath: process.env.WINDOWS_SIGN_HOOK
               }
             }
           : {})
@@ -88,6 +85,13 @@ module.exports = {
   ],
 
   hooks: {
+    readPackageJson: async (forgeConfig, packageJson) => {
+      if (process.env.UPGRADE_KEY) {
+        packageJson.upgrade = process.env.UPGRADE_KEY
+      }
+
+      return packageJson
+    },
     preMake: async () => {
       fs.rmSync(path.join(__dirname, 'out', 'make'), { recursive: true, force: true })
 
@@ -105,11 +109,10 @@ module.exports = {
           fs.mkdirSync(standardDir, { recursive: true })
           const dest = path.join(standardDir, path.basename(artifact))
           fs.renameSync(artifact, dest)
+          fs.mkdirSync(path.dirname(artifact), { recursive: true })
+          fs.copyFileSync(dest, artifact)
           result.artifacts[result.artifacts.indexOf(artifact)] = dest
         }
-      }
-      if (isWindows) {
-        fs.rmSync(path.join(__dirname, 'out', 'make'), { recursive: true, force: true })
       }
     }
   },


### PR DESCRIPTION
1. Builds signed artifacts for **Linux** (x64, ARM), **macOS** (x64, ARM) and **Windows** (x64),
2. Windows now uses the generic GH runner `windows-latest` with the new PFX signing method instead of the custom runner.

---

Test run: https://github.com/AndreiRegiani/hello-pear-electron/actions/runs/26058410876
(secrets under my org "AndreiRegiani")

<img width="325" height="298" alt="image" src="https://github.com/user-attachments/assets/4ab4c8ed-767d-4848-9a31-c36643be09dd" />
