### PR TITLE
Move updater to bare

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -137,10 +137,17 @@ ipcMain.handle('pear:applyUpdate', () => {
   const worker = getWorker(mainWorkerSpecifier)
 
   return new Promise((resolve) => {
-    worker.on('data', (data) => {
+    function onData(data) {
       const message = data.toString()
-      if (message === 'pear:updateApplied') resolve()
-    })
+
+      if (message === 'pear:updateApplied') {
+        worker.removeListener('data', onData)
+        resolve()
+      }
+    }
+
+    worker.on('data', onData)
+
     worker.write(Buffer.from('pear:applyUpdate'))
   })
 })

--- a/electron/main.js
+++ b/electron/main.js
@@ -68,15 +68,15 @@ function getWorker(specifier) {
   }
 
   const extension = isLinux ? '.AppImage' : isMac ? '.app' : '.msix'
-  const updaterConfig = {
+
+  const worker = PearRuntime.run('../' + specifier, [
     dir,
-    app: appPath,
+    appPath,
     updates,
     version,
     upgrade,
-    name: productName + extension
-  }
-  const worker = PearRuntime.run('../' + specifier, [dir, appPath, updates, version, upgrade, productName + extension])
+    productName + extension
+  ])
 
   function sendWorkerStdout(data) {
     sendToAll('pear:worker:stdout:' + specifier, data)

--- a/electron/main.js
+++ b/electron/main.js
@@ -12,7 +12,6 @@ const protocol = name
 const mainWorkerSpecifier = '/workers/main.js'
 
 const workers = new Map()
-let pear = null
 
 const appName = productName ?? name
 
@@ -75,7 +74,7 @@ function getWorker(specifier) {
     updates,
     version,
     upgrade,
-    name: productName + extension,
+    name: productName + extension
   }
   const worker = PearRuntime.run(require.resolve('..' + specifier), [JSON.stringify(updaterConfig)])
 
@@ -123,14 +122,6 @@ async function createWindow() {
     }
   })
 
-  const onUpdating = () => {
-    if (!win.isDestroyed()) win.webContents.send('pear:event:updating')
-  }
-
-  const onUpdated = () => {
-    if (!win.isDestroyed()) win.webContents.send('pear:event:updated')
-  }
-
   const devServerUrl = process.env.PEAR_DEV_SERVER_URL
 
   if (devServerUrl) {
@@ -162,7 +153,7 @@ ipcMain.handle('app:afterUpdate', () => {
   } else if (!isWindows) {
     app.relaunch()
   }
-  app.exit(0)
+  app.quit()
 })
 
 function handleDeepLink(url) {

--- a/electron/main.js
+++ b/electron/main.js
@@ -138,18 +138,23 @@ async function createWindow() {
 ipcMain.handle('pear:applyUpdate', () => {
   const pipe = getWorker(mainWorkerSpecifier)
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      pipe.removeListener('data', onData)
+      reject(new Error('Timed out waiting for pear:updateApplied'))
+    }, 30000)
+
     function onData(data) {
       const message = data.toString()
 
       if (message === 'pear:updateApplied') {
+        clearTimeout(timeout)
         pipe.removeListener('data', onData)
         resolve()
       }
     }
 
     pipe.on('data', onData)
-
     pipe.write('pear:applyUpdate')
   })
 })

--- a/electron/main.js
+++ b/electron/main.js
@@ -64,7 +64,7 @@ function getWorker(specifier) {
         ? isSnap
           ? path.join(process.env.SNAP_USER_COMMON, appName)
           : path.join(linuxConfigHome, appName)
-        : path.join(os.homedir(), 'AppData', 'Local', appName)
+        : path.join(os.homedir(), 'AppData', 'Roaming', appName)
   }
 
   const extension = isLinux ? '.AppImage' : isMac ? '.app' : '.msix'
@@ -133,9 +133,16 @@ async function createWindow() {
   await win.loadFile(path.join(__dirname, '..', 'renderer', 'index.html'))
 }
 
-ipcMain.handle('pear:applyUpdate', () => {
+ipcMain.handle('pear:applyUpdate', async () => {
   const worker = getWorker(mainWorkerSpecifier)
-  worker.write(Buffer.from('pear:applyUpdate'))
+  
+  await new Promise((resolve) => {
+    worker.on('data', (data) => {
+      const message = data.toString()
+      if (message === 'pear:updateApplied') resolve()
+    })
+    worker.write(Buffer.from('pear:applyUpdate'))
+  })
 })
 ipcMain.handle('pear:startWorker', (evt, filename) => {
   getWorker(filename)

--- a/electron/main.js
+++ b/electron/main.js
@@ -69,7 +69,7 @@ function getWorker(specifier) {
 
   const extension = isLinux ? '.AppImage' : isMac ? '.app' : '.msix'
 
-  const worker = PearRuntime.run('../' + specifier, [
+  const worker = PearRuntime.run(require.resolve('..' + specifier), [
     dir,
     appPath,
     updates,

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,8 +1,6 @@
 const { app, BrowserWindow, ipcMain } = require('electron')
 const os = require('os')
 const path = require('path')
-const Hyperswarm = require('hyperswarm')
-const Corestore = require('corestore')
 const PearRuntime = require('pear-runtime')
 
 const { isMac, isLinux, isWindows } = require('which-runtime')
@@ -35,8 +33,21 @@ ipcMain.on('pkg', (evt) => {
   evt.returnValue = pkg
 })
 
-function getPear() {
-  if (pear) return pear
+function getAppPath() {
+  if (!app.isPackaged) return null
+  if (isLinux && process.env.APPIMAGE) return process.env.APPIMAGE
+  if (isWindows) return process.execPath
+  return path.join(process.resourcesPath, '..', '..')
+}
+
+function sendToAll(name, data) {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) win.webContents.send(name, data)
+  }
+}
+
+function getWorker(specifier) {
+  if (workers.has(specifier)) return workers.get(specifier)
   const appPath = getAppPath()
   let dir = null
   if (pearStore) {
@@ -53,46 +64,16 @@ function getPear() {
   }
 
   const extension = isLinux ? '.AppImage' : isMac ? '.app' : '.msix'
-  const store = new Corestore(path.join(dir, 'pear-runtime/corestore'))
-  const swarm = new Hyperswarm()
-  pear = new PearRuntime({
+  const updaterConfig = {
     dir,
     app: appPath,
     updates,
     version,
     upgrade,
     name: productName + extension,
-    store,
-    swarm
-  })
-  if (updates !== false) {
-    swarm.on('connection', (connection) => store.replicate(connection))
-    swarm.join(pear.updater.drive.core.discoveryKey, {
-      client: true,
-      server: false
-    })
   }
-  pear.on('error', console.error) // print network errors, etc.
-  return pear
-}
+  const worker = PearRuntime.run(require.resolve('..' + specifier), [JSON.stringify(updaterConfig)])
 
-function getAppPath() {
-  if (!app.isPackaged) return null
-  if (isLinux && process.env.APPIMAGE) return process.env.APPIMAGE
-  if (isWindows) return process.execPath
-  return path.join(process.resourcesPath, '..', '..')
-}
-
-function sendToAll(name, data) {
-  for (const win of BrowserWindow.getAllWindows()) {
-    if (!win.isDestroyed()) win.webContents.send(name, data)
-  }
-}
-
-function getWorker(specifier) {
-  if (workers.has(specifier)) return workers.get(specifier)
-  const pear = getPear()
-  const worker = pear.run(require.resolve('..' + specifier), [pear.storage])
   function sendWorkerStdout(data) {
     sendToAll('pear:worker:stdout:' + specifier, data)
   }
@@ -137,8 +118,6 @@ async function createWindow() {
     }
   })
 
-  const pear = getPear()
-
   const onUpdating = () => {
     if (!win.isDestroyed()) win.webContents.send('pear:event:updating')
   }
@@ -146,14 +125,6 @@ async function createWindow() {
   const onUpdated = () => {
     if (!win.isDestroyed()) win.webContents.send('pear:event:updated')
   }
-
-  pear.updater.on('updating', onUpdating)
-  pear.updater.on('updated', onUpdated)
-
-  win.on('closed', () => {
-    pear.updater.removeListener('updating', onUpdating)
-    pear.updater.removeListener('updated', onUpdated)
-  })
 
   const devServerUrl = process.env.PEAR_DEV_SERVER_URL
 
@@ -167,8 +138,8 @@ async function createWindow() {
 }
 
 ipcMain.handle('pear:applyUpdate', () => {
-  const pear = getPear()
-  pear.updater.applyUpdate()
+  const worker = getWorker()
+  worker.write(Buffer.from('pear:applyUpdate'))
 })
 ipcMain.handle('pear:startWorker', (evt, filename) => {
   getWorker(filename)

--- a/electron/main.js
+++ b/electron/main.js
@@ -9,6 +9,7 @@ const pkg = require('../package.json')
 const { name, productName, version, upgrade } = pkg
 
 const protocol = name
+const mainWorkerSpecifier = '/workers/main.js'
 
 const workers = new Map()
 let pear = null
@@ -138,7 +139,7 @@ async function createWindow() {
 }
 
 ipcMain.handle('pear:applyUpdate', () => {
-  const worker = getWorker()
+  const worker = getWorker(mainWorkerSpecifier)
   worker.write(Buffer.from('pear:applyUpdate'))
 })
 ipcMain.handle('pear:startWorker', (evt, filename) => {

--- a/electron/main.js
+++ b/electron/main.js
@@ -133,10 +133,10 @@ async function createWindow() {
   await win.loadFile(path.join(__dirname, '..', 'renderer', 'index.html'))
 }
 
-ipcMain.handle('pear:applyUpdate', async () => {
+ipcMain.handle('pear:applyUpdate', () => {
   const worker = getWorker(mainWorkerSpecifier)
-  
-  await new Promise((resolve) => {
+
+  return new Promise((resolve) => {
     worker.on('data', (data) => {
       const message = data.toString()
       if (message === 'pear:updateApplied') resolve()

--- a/electron/main.js
+++ b/electron/main.js
@@ -2,6 +2,7 @@ const { app, BrowserWindow, ipcMain } = require('electron')
 const os = require('os')
 const path = require('path')
 const PearRuntime = require('pear-runtime')
+const FramedStream = require('framed-stream')
 
 const { isMac, isLinux, isWindows } = require('which-runtime')
 const { command, flag } = require('paparam')
@@ -77,6 +78,7 @@ function getWorker(specifier) {
     upgrade,
     productName + extension
   ])
+  const pipe = new FramedStream(worker)
 
   function sendWorkerStdout(data) {
     sendToAll('pear:worker:stdout:' + specifier, data)
@@ -88,26 +90,26 @@ function getWorker(specifier) {
     sendToAll('pear:worker:ipc:' + specifier, data)
   }
   function onBeforeQuit() {
-    worker.destroy()
+    pipe.destroy()
   }
   ipcMain.handle('pear:worker:writeIPC:' + specifier, (evt, data) => {
-    return worker.write(Buffer.from(data))
+    return pipe.write(data)
   })
-  workers.set(specifier, worker)
-  worker.on('data', sendWorkerIPC)
+  workers.set(specifier, pipe)
+  pipe.on('data', sendWorkerIPC)
   worker.stdout.on('data', sendWorkerStdout)
   worker.stderr.on('data', sendWorkerStderr)
   worker.once('exit', (code) => {
     app.removeListener('before-quit', onBeforeQuit)
     ipcMain.removeHandler('pear:worker:writeIPC:' + specifier)
-    worker.removeListener('data', sendWorkerIPC)
+    pipe.removeListener('data', sendWorkerIPC)
     worker.stdout.removeListener('data', sendWorkerStdout)
     worker.stderr.removeListener('data', sendWorkerStderr)
     sendToAll('pear:worker:exit:' + specifier, code)
     workers.delete(specifier)
   })
   app.on('before-quit', onBeforeQuit)
-  return worker
+  return pipe
 }
 
 async function createWindow() {
@@ -134,21 +136,21 @@ async function createWindow() {
 }
 
 ipcMain.handle('pear:applyUpdate', () => {
-  const worker = getWorker(mainWorkerSpecifier)
+  const pipe = getWorker(mainWorkerSpecifier)
 
   return new Promise((resolve) => {
     function onData(data) {
       const message = data.toString()
 
       if (message === 'pear:updateApplied') {
-        worker.removeListener('data', onData)
+        pipe.removeListener('data', onData)
         resolve()
       }
     }
 
-    worker.on('data', onData)
+    pipe.on('data', onData)
 
-    worker.write(Buffer.from('pear:applyUpdate'))
+    pipe.write('pear:applyUpdate')
   })
 })
 ipcMain.handle('pear:startWorker', (evt, filename) => {

--- a/electron/main.js
+++ b/electron/main.js
@@ -76,7 +76,7 @@ function getWorker(specifier) {
     upgrade,
     name: productName + extension
   }
-  const worker = PearRuntime.run(require.resolve('..' + specifier), [JSON.stringify(updaterConfig)])
+  const worker = PearRuntime.run('../' + specifier, [dir, appPath, updates, version, upgrade, productName + extension])
 
   function sendWorkerStdout(data) {
     sendToAll('pear:worker:stdout:' + specifier, data)

--- a/electron/main.js
+++ b/electron/main.js
@@ -139,16 +139,10 @@ ipcMain.handle('pear:applyUpdate', () => {
   const pipe = getWorker(mainWorkerSpecifier)
 
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      pipe.removeListener('data', onData)
-      reject(new Error('Timed out waiting for pear:updateApplied'))
-    }, 30000)
-
     function onData(data) {
       const message = data.toString()
 
       if (message === 'pear:updateApplied') {
-        clearTimeout(timeout)
         pipe.removeListener('data', onData)
         resolve()
       }

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,4 +1,13 @@
 const { contextBridge, ipcRenderer } = require('electron')
+
+function toBuffer(data) {
+  if (Buffer.isBuffer(data)) return data
+  if (ArrayBuffer.isView(data)) return Buffer.from(data.buffer, data.byteOffset, data.byteLength)
+  if (data instanceof ArrayBuffer) return Buffer.from(data)
+  if (data && Array.isArray(data.data)) return Buffer.from(data.data)
+  return Buffer.from(String(data))
+}
+
 contextBridge.exposeInMainWorld('bridge', {
   pkg() {
     return ipcRenderer.sendSync('pkg')
@@ -7,22 +16,22 @@ contextBridge.exposeInMainWorld('bridge', {
   appAfterUpdate: () => ipcRenderer.invoke('app:afterUpdate'),
   startWorker: (specifier) => ipcRenderer.invoke('pear:startWorker', specifier),
   onWorkerStdout: (specifier, listener) => {
-    const wrap = (evt, data) => listener(Buffer.from(data))
+    const wrap = (evt, data) => listener(toBuffer(data))
     ipcRenderer.on('pear:worker:stdout:' + specifier, wrap)
     return () => ipcRenderer.removeListener('pear:worker:stdout:' + specifier, wrap)
   },
   onWorkerStderr: (specifier, listener) => {
-    const wrap = (evt, data) => listener(Buffer.from(data))
+    const wrap = (evt, data) => listener(toBuffer(data))
     ipcRenderer.on('pear:worker:stderr:' + specifier, wrap)
     return () => ipcRenderer.removeListener('pear:worker:stderr:' + specifier, wrap)
   },
   onWorkerIPC: (specifier, listener) => {
-    const wrap = (evt, data) => listener(Buffer.from(data))
+    const wrap = (evt, data) => listener(toBuffer(data))
     ipcRenderer.on('pear:worker:ipc:' + specifier, wrap)
     return () => ipcRenderer.removeListener('pear:worker:ipc:' + specifier, wrap)
   },
   onWorkerExit: (specifier, listener) => {
-    const wrap = (evt, data) => listener(Buffer.from(data))
+    const wrap = (evt, code) => listener(code)
     ipcRenderer.on('pear:worker:exit:' + specifier, wrap)
     return () => ipcRenderer.removeListener('pear:worker:exit:' + specifier, wrap)
   },

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,11 +1,8 @@
 const { contextBridge, ipcRenderer } = require('electron')
 
-function toBuffer(data) {
-  if (Buffer.isBuffer(data)) return data
-  if (ArrayBuffer.isView(data)) return Buffer.from(data.buffer, data.byteOffset, data.byteLength)
-  if (data instanceof ArrayBuffer) return Buffer.from(data)
-  if (data && Array.isArray(data.data)) return Buffer.from(data.data)
-  return Buffer.from(String(data))
+function toBuffer (data) {
+  if (data === null || data === undefined || typeof data === 'number') return data
+  return Buffer.from(data.buffer, data.byteOffset, data.byteLength)
 }
 
 contextBridge.exposeInMainWorld('bridge', {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -5,11 +5,6 @@ contextBridge.exposeInMainWorld('bridge', {
   },
   applyUpdate: () => ipcRenderer.invoke('pear:applyUpdate'),
   appAfterUpdate: () => ipcRenderer.invoke('app:afterUpdate'),
-  onPearEvent: (name, listener) => {
-    const wrap = (evt, eventName) => listener(eventName)
-    ipcRenderer.on('pear:event:' + name, wrap)
-    return () => ipcRenderer.removeListener('pear:event:' + name, wrap)
-  },
   startWorker: (specifier) => ipcRenderer.invoke('pear:startWorker', specifier),
   onWorkerStdout: (specifier, listener) => {
     const wrap = (evt, data) => listener(Buffer.from(data))

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,6 +1,6 @@
 const { contextBridge, ipcRenderer } = require('electron')
 
-function toBuffer (data) {
+function toBuffer(data) {
   if (data === null || data === undefined || typeof data === 'number') return data
   return Buffer.from(data.buffer, data.byteOffset, data.byteLength)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,16 @@
 {
   "name": "hello-pear-electron",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hello-pear-electron",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "dependencies": {
         "corestore": "^7.9.1",
+        "framed-stream": "^1.0.1",
+        "graceful-goodbye": "^1.3.3",
         "hyperswarm": "^4.17.0",
         "paparam": "^1.10.0",
         "pear-runtime": "^1.1.4",
@@ -2528,9 +2530,7 @@
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/bare-abort/-/bare-abort-2.0.13.tgz",
       "integrity": "sha512-zdc8l88eB11Jsz5rDd6sCAgv2kUFXgdrZWoMlgU6JMkfAi1/uuGFC3IEHswKbIRQTk5H3T5CMuechsXYxiaHlQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true
+      "license": "Apache-2.0"
     },
     "node_modules/bare-addon-resolve": {
       "version": "1.10.0",
@@ -2683,9 +2683,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bare-hrtime/-/bare-hrtime-2.1.1.tgz",
       "integrity": "sha512-VMb3tHo05gsnbu3OXTmkDiwTjMlOsbQmKoysKqKEyR09m77TuDrYFbj3Q5GGk10dAKsUHrnXmwCaeJqzVpB5ZA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true
+      "license": "Apache-2.0"
     },
     "node_modules/bare-inspect": {
       "version": "3.1.4",
@@ -2793,9 +2791,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/bare-process/-/bare-process-4.4.1.tgz",
       "integrity": "sha512-JfcTtymq6akqM2bdyTsP4A4GYJceBzb91k/ECmFps75uFf6uO33SM1bOZsRAqyRXExabsQJLn5S41NBl8HTM4A==",
-      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-abort": "^2.0.13",
         "bare-env": "^3.0.0",
@@ -2857,9 +2853,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/bare-signals/-/bare-signals-4.2.0.tgz",
       "integrity": "sha512-fNHMOdQIlYuTvMB3Oh9Apk99hLKn351+Ir8vz+khiPTcOqIyGG4uWWjdLTzxWdYGsA0eT+We3y0K74hjj2nq7A==",
-      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-events": "^2.5.3",
         "bare-os": "^3.3.1"
@@ -2872,9 +2866,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bare-stdio/-/bare-stdio-1.0.2.tgz",
       "integrity": "sha512-3WJDqtvVGP4f+j68kyEC05umOYNwKJ1xG+YAXL8yZ605WgNqiRhVaFq+mVIhBt2eKNp7pa5vCQdhOt1pNh79SA==",
-      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-fs": "^4.5.2",
         "bare-pipe": "^4.1.5",
@@ -2949,9 +2941,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bare-tty/-/bare-tty-5.1.0.tgz",
       "integrity": "sha512-EZLvW4A+XiJgI3TW+e1pMME9PIJsfEXe/DA/WSKzIkq/v7Yarpv/rvG6Z5pGnpo4V/Bd+qopwnCLSR71hMMBYA==",
-      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-events": "^2.2.0",
         "bare-signals": "^4.0.0",
@@ -5564,6 +5554,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framed-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/framed-stream/-/framed-stream-1.0.1.tgz",
+      "integrity": "sha512-x0At1ETY20yXARxM6Qr5BGasgPpD0/HVYDyA7Uiaf9LfSqrb8p/F9i0s2/8YoeHkZcJeKsnwWBrnJCfZZoxHjA==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.1",
+        "streamx": "^2.13.0"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -5981,6 +5981,16 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/graceful-goodbye": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/graceful-goodbye/-/graceful-goodbye-1.3.3.tgz",
+      "integrity": "sha512-ABj07mmHrK3FC8fJ3PP5QCrbA31zkB4Qg34NFmYgwJnBxzfbRmtMzOg54PL55OG5sFjvmBzD0q85JAtRlA3dSA==",
+      "license": "MIT",
+      "dependencies": {
+        "bare-process": "^4.0.0",
+        "safety-catch": "^1.0.2"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hello-pear-electron",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hello-pear-electron",
-      "version": "2.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "corestore": "^7.9.1",
         "framed-stream": "^1.0.1",
@@ -996,6 +996,7 @@
       "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^3.0.1",
         "@inquirer/confirm": "^4.0.1",
@@ -1556,7 +1557,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "xmlbuilder": ">=11.0.1"
@@ -1578,8 +1578,7 @@
       "integrity": "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
@@ -1811,6 +1810,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1883,6 +1883,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2333,7 +2334,6 @@
       "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.4",
@@ -2353,7 +2353,6 @@
       "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.0",
@@ -2376,7 +2375,6 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -2392,8 +2390,7 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/archiver-utils/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -2401,7 +2398,6 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -2411,8 +2407,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/are-we-there-yet": {
       "version": "3.0.1",
@@ -2443,7 +2438,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -2455,7 +2449,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3173,6 +3166,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3545,7 +3539,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "slice-ansi": "^3.0.0",
         "string-width": "^4.2.0"
@@ -3735,7 +3728,6 @@
       "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-crc32": "^0.2.13",
         "crc32-stream": "^4.0.2",
@@ -3834,8 +3826,7 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/corestore": {
       "version": "7.9.2",
@@ -3860,7 +3851,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "buffer": "^5.1.0"
       }
@@ -3871,7 +3861,6 @@
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -3885,7 +3874,6 @@
       "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
@@ -4162,7 +4150,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "dependencies": {
         "@types/plist": "^3.0.1",
         "@types/verror": "^1.10.3",
@@ -4741,7 +4728,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -4762,7 +4748,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -4778,7 +4763,6 @@
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -4789,7 +4773,6 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -4892,17 +4875,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -5309,8 +5281,7 @@
         "node >=0.6.0"
       ],
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5569,8 +5540,7 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -6350,7 +6320,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "dependencies": {
         "cli-truncate": "^2.1.0",
         "node-addon-api": "^1.6.3"
@@ -6692,8 +6661,7 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/isbinaryfile": {
       "version": "4.0.10",
@@ -6911,7 +6879,6 @@
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -6925,7 +6892,6 @@
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -6941,8 +6907,7 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -6950,7 +6915,6 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -7178,24 +7142,21 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
@@ -7210,16 +7171,14 @@
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -7944,8 +7903,7 @@
       "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/node-api-version": {
       "version": "0.2.1",
@@ -8209,7 +8167,6 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9220,6 +9177,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9255,8 +9213,7 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -9585,7 +9542,6 @@
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "minimatch": "^5.1.0"
       }
@@ -9596,7 +9552,6 @@
       "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -9607,7 +9562,6 @@
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -10006,6 +9960,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10192,7 +10147,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -10612,7 +10566,6 @@
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -10649,7 +10602,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -10675,7 +10627,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -10690,7 +10641,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -10875,6 +10825,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11217,7 +11168,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -11552,7 +11502,6 @@
       "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "archiver-utils": "^3.0.4",
         "compress-commons": "^4.1.2",
@@ -11568,7 +11517,6 @@
       "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob": "^7.2.3",
         "graceful-fs": "^4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "corestore": "^7.9.2",
         "hyperswarm": "^4.17.0",
         "paparam": "^1.10.1",
-        "pear-runtime": "^1.1.3",
+        "pear-runtime": "^1.1.4",
         "which-runtime": "^1.4.0"
       },
       "devDependencies": {
@@ -9094,9 +9094,9 @@
       }
     },
     "node_modules/pear-runtime": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/pear-runtime/-/pear-runtime-1.1.3.tgz",
-      "integrity": "sha512-kBtUACxKslUDXQzHEkdUBI0T4AwnGgwYqogsOnACOscmhpz33U1eSwxxhxfSW1gUXBdnyjradirEexNZ/nj2vg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pear-runtime/-/pear-runtime-1.1.4.tgz",
+      "integrity": "sha512-HfqoCYpVV6IBgyBbRXBjG8A8Ezm3JWW+pOtTQEoWh+DZ7e8x4xg+JkbdaOnAaQpVraXHdd77qd85fI4l/Rxlpg==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "bare-path": "^3.0.0",
         "corestore": "^7.9.2",
+        "graceful-goodbye": "^1.3.3",
         "hyperswarm": "^4.17.0",
         "paparam": "^1.10.1",
         "pear-runtime": "^1.1.4",
@@ -2529,9 +2530,7 @@
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/bare-abort/-/bare-abort-2.0.13.tgz",
       "integrity": "sha512-zdc8l88eB11Jsz5rDd6sCAgv2kUFXgdrZWoMlgU6JMkfAi1/uuGFC3IEHswKbIRQTk5H3T5CMuechsXYxiaHlQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true
+      "license": "Apache-2.0"
     },
     "node_modules/bare-addon-resolve": {
       "version": "1.10.0",
@@ -2684,9 +2683,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bare-hrtime/-/bare-hrtime-2.1.1.tgz",
       "integrity": "sha512-VMb3tHo05gsnbu3OXTmkDiwTjMlOsbQmKoysKqKEyR09m77TuDrYFbj3Q5GGk10dAKsUHrnXmwCaeJqzVpB5ZA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true
+      "license": "Apache-2.0"
     },
     "node_modules/bare-inspect": {
       "version": "3.1.4",
@@ -2794,9 +2791,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/bare-process/-/bare-process-4.4.1.tgz",
       "integrity": "sha512-JfcTtymq6akqM2bdyTsP4A4GYJceBzb91k/ECmFps75uFf6uO33SM1bOZsRAqyRXExabsQJLn5S41NBl8HTM4A==",
-      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-abort": "^2.0.13",
         "bare-env": "^3.0.0",
@@ -2858,9 +2853,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/bare-signals/-/bare-signals-4.2.0.tgz",
       "integrity": "sha512-fNHMOdQIlYuTvMB3Oh9Apk99hLKn351+Ir8vz+khiPTcOqIyGG4uWWjdLTzxWdYGsA0eT+We3y0K74hjj2nq7A==",
-      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-events": "^2.5.3",
         "bare-os": "^3.3.1"
@@ -2873,9 +2866,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bare-stdio/-/bare-stdio-1.0.2.tgz",
       "integrity": "sha512-3WJDqtvVGP4f+j68kyEC05umOYNwKJ1xG+YAXL8yZ605WgNqiRhVaFq+mVIhBt2eKNp7pa5vCQdhOt1pNh79SA==",
-      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-fs": "^4.5.2",
         "bare-pipe": "^4.1.5",
@@ -2950,9 +2941,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bare-tty/-/bare-tty-5.1.0.tgz",
       "integrity": "sha512-EZLvW4A+XiJgI3TW+e1pMME9PIJsfEXe/DA/WSKzIkq/v7Yarpv/rvG6Z5pGnpo4V/Bd+qopwnCLSR71hMMBYA==",
-      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-events": "^2.2.0",
         "bare-signals": "^4.0.0",
@@ -5982,6 +5971,16 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/graceful-goodbye": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/graceful-goodbye/-/graceful-goodbye-1.3.3.tgz",
+      "integrity": "sha512-ABj07mmHrK3FC8fJ3PP5QCrbA31zkB4Qg34NFmYgwJnBxzfbRmtMzOg54PL55OG5sFjvmBzD0q85JAtRlA3dSA==",
+      "license": "MIT",
+      "dependencies": {
+        "bare-process": "^4.0.0",
+        "safety-catch": "^1.0.2"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,30 +8,28 @@
       "name": "hello-pear-electron",
       "version": "1.0.0",
       "dependencies": {
-        "bare-path": "^3.0.0",
-        "corestore": "^7.9.2",
-        "graceful-goodbye": "^1.3.3",
+        "corestore": "^7.9.1",
         "hyperswarm": "^4.17.0",
-        "paparam": "^1.10.1",
+        "paparam": "^1.10.0",
         "pear-runtime": "^1.1.4",
-        "which-runtime": "^1.4.0"
+        "which-runtime": "^1.3.2"
       },
       "devDependencies": {
-        "@electron-forge/cli": "^7.11.2",
-        "@electron-forge/maker-deb": "^7.11.2",
-        "@electron-forge/maker-dmg": "^7.11.2",
-        "@electron-forge/maker-msix": "^7.11.2",
-        "@electron-forge/maker-rpm": "^7.11.2",
-        "@electron-forge/maker-zip": "^7.11.2",
+        "@electron-forge/cli": "^7.11.1",
+        "@electron-forge/maker-deb": "^7.11.1",
+        "@electron-forge/maker-dmg": "^7.11.1",
+        "@electron-forge/maker-msix": "^7.11.1",
+        "@electron-forge/maker-rpm": "^7.11.1",
+        "@electron-forge/maker-zip": "^7.11.1",
         "app-builder-lib": "^26.8.1",
-        "electron": "^40.10.1",
-        "electron-forge-plugin-prune-prebuilds": "^1.0.1",
+        "electron": "^40.2.1",
+        "electron-forge-plugin-prune-prebuilds": "^1.0.0",
         "electron-forge-plugin-universal-prebuilds": "^1.0.0",
-        "lunte": "^1.8.0",
+        "lunte": "^1.6.0",
         "pear-electron-forge-maker-appimage": "^2.0.0",
         "pear-electron-forge-maker-flatpak": "^0.0.4",
         "pear-electron-forge-maker-snap": "^0.0.10",
-        "prettier": "^3.8.3",
+        "prettier": "^3.8.1",
         "prettier-config-holepunch": "^2.0.0"
       }
     },
@@ -2530,7 +2528,9 @@
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/bare-abort/-/bare-abort-2.0.13.tgz",
       "integrity": "sha512-zdc8l88eB11Jsz5rDd6sCAgv2kUFXgdrZWoMlgU6JMkfAi1/uuGFC3IEHswKbIRQTk5H3T5CMuechsXYxiaHlQ==",
-      "license": "Apache-2.0"
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/bare-addon-resolve": {
       "version": "1.10.0",
@@ -2683,7 +2683,9 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bare-hrtime/-/bare-hrtime-2.1.1.tgz",
       "integrity": "sha512-VMb3tHo05gsnbu3OXTmkDiwTjMlOsbQmKoysKqKEyR09m77TuDrYFbj3Q5GGk10dAKsUHrnXmwCaeJqzVpB5ZA==",
-      "license": "Apache-2.0"
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/bare-inspect": {
       "version": "3.1.4",
@@ -2791,7 +2793,9 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/bare-process/-/bare-process-4.4.1.tgz",
       "integrity": "sha512-JfcTtymq6akqM2bdyTsP4A4GYJceBzb91k/ECmFps75uFf6uO33SM1bOZsRAqyRXExabsQJLn5S41NBl8HTM4A==",
+      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "bare-abort": "^2.0.13",
         "bare-env": "^3.0.0",
@@ -2853,7 +2857,9 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/bare-signals/-/bare-signals-4.2.0.tgz",
       "integrity": "sha512-fNHMOdQIlYuTvMB3Oh9Apk99hLKn351+Ir8vz+khiPTcOqIyGG4uWWjdLTzxWdYGsA0eT+We3y0K74hjj2nq7A==",
+      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "bare-events": "^2.5.3",
         "bare-os": "^3.3.1"
@@ -2866,7 +2872,9 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bare-stdio/-/bare-stdio-1.0.2.tgz",
       "integrity": "sha512-3WJDqtvVGP4f+j68kyEC05umOYNwKJ1xG+YAXL8yZ605WgNqiRhVaFq+mVIhBt2eKNp7pa5vCQdhOt1pNh79SA==",
+      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "bare-fs": "^4.5.2",
         "bare-pipe": "^4.1.5",
@@ -2941,7 +2949,9 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bare-tty/-/bare-tty-5.1.0.tgz",
       "integrity": "sha512-EZLvW4A+XiJgI3TW+e1pMME9PIJsfEXe/DA/WSKzIkq/v7Yarpv/rvG6Z5pGnpo4V/Bd+qopwnCLSR71hMMBYA==",
+      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "bare-events": "^2.2.0",
         "bare-signals": "^4.0.0",
@@ -5971,16 +5981,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/graceful-goodbye": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/graceful-goodbye/-/graceful-goodbye-1.3.3.tgz",
-      "integrity": "sha512-ABj07mmHrK3FC8fJ3PP5QCrbA31zkB4Qg34NFmYgwJnBxzfbRmtMzOg54PL55OG5sFjvmBzD0q85JAtRlA3dSA==",
-      "license": "MIT",
-      "dependencies": {
-        "bare-process": "^4.0.0",
-        "safety-catch": "^1.0.2"
-      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,24 +11,24 @@
         "bare-path": "^3.0.0",
         "corestore": "^7.9.2",
         "hyperswarm": "^4.17.0",
-        "paparam": "^1.10.0",
+        "paparam": "^1.10.1",
         "pear-runtime": "^1.1.3",
-        "which-runtime": "^1.3.2"
+        "which-runtime": "^1.4.0"
       },
       "devDependencies": {
-        "@electron-forge/cli": "^7.11.1",
-        "@electron-forge/maker-deb": "^7.11.1",
-        "@electron-forge/maker-dmg": "^7.11.1",
-        "@electron-forge/maker-msix": "^7.11.1",
-        "@electron-forge/maker-rpm": "^7.11.1",
-        "@electron-forge/maker-zip": "^7.11.1",
+        "@electron-forge/cli": "^7.11.2",
+        "@electron-forge/maker-deb": "^7.11.2",
+        "@electron-forge/maker-dmg": "^7.11.2",
+        "@electron-forge/maker-msix": "^7.11.2",
+        "@electron-forge/maker-rpm": "^7.11.2",
+        "@electron-forge/maker-zip": "^7.11.2",
         "app-builder-lib": "^26.8.1",
-        "electron": "^40.2.1",
-        "electron-forge-plugin-prune-prebuilds": "^1.0.0",
+        "electron": "^40.10.1",
+        "electron-forge-plugin-prune-prebuilds": "^1.0.1",
         "electron-forge-plugin-universal-prebuilds": "^1.0.0",
-        "lunte": "^1.6.0",
+        "lunte": "^1.8.0",
         "pear-electron-forge-maker-appimage": "^2.0.0",
-        "prettier": "^3.8.1",
+        "prettier": "^3.8.3",
         "prettier-config-holepunch": "^2.0.0"
       }
     },
@@ -51,25 +51,21 @@
       }
     },
     "node_modules/@electron-forge/cli": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-7.11.1.tgz",
-      "integrity": "sha512-pk8AoLsr7t7LBAt0cFD06XFA6uxtPdvtLx06xeal7O9o7GHGCbj29WGwFoJ8Br/ENM0Ho868S3PrAn1PtBXt5g==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-7.11.2.tgz",
+      "integrity": "sha512-c+C4ndLfHbxwZuCn9G8iT9wD/woLdaVkoSVjAIbj+0nJhi8UmiVsz/+Gxlj4cvhMRTzBMBxudstLU7RocMikfg==",
       "dev": true,
       "funding": [
         {
-          "type": "individual",
-          "url": "https://github.com/sponsors/malept"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/subscription/pkg/npm-.electron-forge-cli?utm_medium=referral&utm_source=npm_fund"
+          "type": "opencollective",
+          "url": "https://opencollective.com/electron"
         }
       ],
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/core": "7.11.1",
-        "@electron-forge/core-utils": "7.11.1",
-        "@electron-forge/shared-types": "7.11.1",
+        "@electron-forge/core": "7.11.2",
+        "@electron-forge/core-utils": "7.11.2",
+        "@electron-forge/shared-types": "7.11.2",
         "@electron/get": "^3.0.0",
         "@inquirer/prompts": "^6.0.1",
         "@listr2/prompt-adapter-inquirer": "^2.0.22",
@@ -91,33 +87,29 @@
       }
     },
     "node_modules/@electron-forge/core": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/core/-/core-7.11.1.tgz",
-      "integrity": "sha512-YtuPLzggPKPabFAD2rOZFE0s7f4KaUTpGRduhSMbZUqpqD1TIPyfoDBpYiZvao3Ht8pyZeOJjbzcC0LpFs9gIQ==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/core/-/core-7.11.2.tgz",
+      "integrity": "sha512-RbOvlCahSlYBkY1XFgD5QuoifZltEY3ezYGqJYnV1z6RiUK1DfUXwdidmclBLI9d6u8NNr9xWPv79LHVc9ZA3Q==",
       "dev": true,
       "funding": [
         {
-          "type": "individual",
-          "url": "https://github.com/sponsors/malept"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/subscription/pkg/npm-.electron-forge-core?utm_medium=referral&utm_source=npm_fund"
+          "type": "opencollective",
+          "url": "https://opencollective.com/electron"
         }
       ],
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/core-utils": "7.11.1",
-        "@electron-forge/maker-base": "7.11.1",
-        "@electron-forge/plugin-base": "7.11.1",
-        "@electron-forge/publisher-base": "7.11.1",
-        "@electron-forge/shared-types": "7.11.1",
-        "@electron-forge/template-base": "7.11.1",
-        "@electron-forge/template-vite": "7.11.1",
-        "@electron-forge/template-vite-typescript": "7.11.1",
-        "@electron-forge/template-webpack": "7.11.1",
-        "@electron-forge/template-webpack-typescript": "7.11.1",
-        "@electron-forge/tracer": "7.11.1",
+        "@electron-forge/core-utils": "7.11.2",
+        "@electron-forge/maker-base": "7.11.2",
+        "@electron-forge/plugin-base": "7.11.2",
+        "@electron-forge/publisher-base": "7.11.2",
+        "@electron-forge/shared-types": "7.11.2",
+        "@electron-forge/template-base": "7.11.2",
+        "@electron-forge/template-vite": "7.11.2",
+        "@electron-forge/template-vite-typescript": "7.11.2",
+        "@electron-forge/template-webpack": "7.11.2",
+        "@electron-forge/template-webpack-typescript": "7.11.2",
+        "@electron-forge/tracer": "7.11.2",
         "@electron/get": "^3.0.0",
         "@electron/packager": "^18.3.5",
         "@electron/rebuild": "^3.7.0",
@@ -125,6 +117,7 @@
         "@vscode/sudo-prompt": "^9.3.1",
         "chalk": "^4.0.0",
         "debug": "^4.3.1",
+        "eta": "^3.5.0",
         "fast-glob": "^3.2.7",
         "filenamify": "^4.1.0",
         "find-up": "^5.0.0",
@@ -134,7 +127,6 @@
         "interpret": "^3.1.1",
         "jiti": "^2.4.2",
         "listr2": "^7.0.2",
-        "lodash": "^4.17.20",
         "log-symbols": "^4.0.0",
         "node-fetch": "^2.6.7",
         "rechoir": "^0.8.0",
@@ -147,13 +139,13 @@
       }
     },
     "node_modules/@electron-forge/core-utils": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/core-utils/-/core-utils-7.11.1.tgz",
-      "integrity": "sha512-9UxRWVsfcziBsbAA2MS0Oz4yYovQCO2BhnGIfsbKNTBtMc/RcVSxAS0NMyymce44i43p1ZC/FqWhnt1XqYw3bQ==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/core-utils/-/core-utils-7.11.2.tgz",
+      "integrity": "sha512-/Fpwo44an6ulUdq94co5OOcbRCohgYNci/E6eoZZuTO9f72X+PqJkMkghqkMX3iQ8Aq2QRLkGKFwrKWJNTjL7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.11.1",
+        "@electron-forge/shared-types": "7.11.2",
         "@electron/rebuild": "^3.7.0",
         "@malept/cross-spawn-promise": "^2.0.0",
         "chalk": "^4.0.0",
@@ -169,13 +161,13 @@
       }
     },
     "node_modules/@electron-forge/maker-base": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.11.1.tgz",
-      "integrity": "sha512-yhZrCGoN6bDeiB5DHFaueZ1h84AReElEj+f0hl2Ph4UbZnO0cnLpbx+Bs+XfMLAiA+beC8muB5UDK5ysfuT9BQ==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.11.2.tgz",
+      "integrity": "sha512-9934zYu9WVdgCYQXvtS+eL1oyLagsY8JlWhZmoK8yWTYftSAydH7jb3seVpfy6n85SYmY/yjcAy2lvOTy5dUwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.11.1",
+        "@electron-forge/shared-types": "7.11.2",
         "fs-extra": "^10.0.0",
         "which": "^2.0.2"
       },
@@ -184,14 +176,14 @@
       }
     },
     "node_modules/@electron-forge/maker-deb": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-deb/-/maker-deb-7.11.1.tgz",
-      "integrity": "sha512-QTYiryQLYPDkq6pIfBmx0GQ6D8QatUkowH7rTlW5MnCUa0uumX0Xu7yGIjesuwW37fxT3Lv4xi+FSXMCm2eC1w==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-deb/-/maker-deb-7.11.2.tgz",
+      "integrity": "sha512-MYSdCTsqzKNmsmaq7CIFh2kJdBWUZ4njxnVGrIRClzueVITk5Kots3+eQo+e5QQLvXTVn2XTNDc2nYjvtBh+Mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/maker-base": "7.11.1",
-        "@electron-forge/shared-types": "7.11.1"
+        "@electron-forge/maker-base": "7.11.2",
+        "@electron-forge/shared-types": "7.11.2"
       },
       "engines": {
         "node": ">= 16.4.0"
@@ -201,14 +193,14 @@
       }
     },
     "node_modules/@electron-forge/maker-dmg": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-dmg/-/maker-dmg-7.11.1.tgz",
-      "integrity": "sha512-7zs5/Ewz1PcOl4N1102stFgBiFGWxU18+UPFUSd/fgf9MErBl4HBWuVNMIHyeJ/56rdfkcmTxTqE+9TBEYrZcg==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-dmg/-/maker-dmg-7.11.2.tgz",
+      "integrity": "sha512-vh8/mnu3xyMbRcz3S0TV1rB7ZyGhMK60Yz2f2R+Zmj1EbAivLEq5UAvzHdB+kLttr0Dpjp2FIX4TcZ9neD4Y9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/maker-base": "7.11.1",
-        "@electron-forge/shared-types": "7.11.1",
+        "@electron-forge/maker-base": "7.11.2",
+        "@electron-forge/shared-types": "7.11.2",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -219,15 +211,15 @@
       }
     },
     "node_modules/@electron-forge/maker-msix": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-msix/-/maker-msix-7.11.1.tgz",
-      "integrity": "sha512-i9+Dp+B0mKscIsaVYhxeaXurKaT4K7geqwzDJUOZlOTfSmID6XIgBq7IINONLg8f/CGp+3rdQqHbn551bNsNQw==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-msix/-/maker-msix-7.11.2.tgz",
+      "integrity": "sha512-02+KlzPyY1aJRT3mNLyx8j5PUPVUA6fvx4DzCgUUkE1XJlu+YPkKoJZL/n1o05Y9UzoIJ1y5b9o1nmNuzyeiXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/core-utils": "7.11.1",
-        "@electron-forge/maker-base": "7.11.1",
-        "@electron-forge/shared-types": "7.11.1",
+        "@electron-forge/core-utils": "7.11.2",
+        "@electron-forge/maker-base": "7.11.2",
+        "@electron-forge/shared-types": "7.11.2",
         "cross-spawn": "^7.0.3",
         "electron-windows-msix": "^2.0.4",
         "fs-extra": "^10.0.0",
@@ -238,14 +230,14 @@
       }
     },
     "node_modules/@electron-forge/maker-rpm": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-rpm/-/maker-rpm-7.11.1.tgz",
-      "integrity": "sha512-iEfJPRQQyaTqk2EbUfZgulChNWvxGXeYUH0xBX/r5cj1pL4vcJXt3jLMQBVn3mk/0Ytv9UWRs8R/XuNWX6sf2w==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-rpm/-/maker-rpm-7.11.2.tgz",
+      "integrity": "sha512-BEj/DcW6bSpmOyKUa3UsOgT7Hm3ZuP0Wa6OuQEunjxeCWn7yoDTDtjuYA0xRvzk+T4NCyDO3RBGjy6nYNSPU2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/maker-base": "7.11.1",
-        "@electron-forge/shared-types": "7.11.1"
+        "@electron-forge/maker-base": "7.11.2",
+        "@electron-forge/shared-types": "7.11.2"
       },
       "engines": {
         "node": ">= 16.4.0"
@@ -255,14 +247,14 @@
       }
     },
     "node_modules/@electron-forge/maker-zip": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-zip/-/maker-zip-7.11.1.tgz",
-      "integrity": "sha512-30rcp0AbJLfkFBX2hmO14LKXx7z9V61LffTVbTCFMh5vUB2kZvcA5xAhsBk2oUJWfGVxe1DuSEU0rDR9bUMHUg==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-zip/-/maker-zip-7.11.2.tgz",
+      "integrity": "sha512-FWnOm2MORX/nt8psnEtID3Vnt8Blby1NkzjU3KjXBPF9kave71C3lI8KbBbCeKKyTQ/S00i2FiglKdRWQ1WNTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/maker-base": "7.11.1",
-        "@electron-forge/shared-types": "7.11.1",
+        "@electron-forge/maker-base": "7.11.2",
+        "@electron-forge/shared-types": "7.11.2",
         "cross-zip": "^4.0.0",
         "fs-extra": "^10.0.0",
         "got": "^11.8.5"
@@ -272,39 +264,39 @@
       }
     },
     "node_modules/@electron-forge/plugin-base": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/plugin-base/-/plugin-base-7.11.1.tgz",
-      "integrity": "sha512-lKpSOV1GA3FoYiD9k05i6v4KaQVmojnRgCr7d6VL1bFp13QOtXSaAWhFI9mtSY7rGElOacX6Zt7P7rPoB8T9eQ==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/plugin-base/-/plugin-base-7.11.2.tgz",
+      "integrity": "sha512-tIFzEE2+D9NnCAn/rLwSkh8H59IqN+G973JNl7xmCzquO6qa7/veitZOQFGO79Zmmgkc8R/fmiCbh7LIdLS9Tg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.11.1"
+        "@electron-forge/shared-types": "7.11.2"
       },
       "engines": {
         "node": ">= 16.4.0"
       }
     },
     "node_modules/@electron-forge/publisher-base": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-base/-/publisher-base-7.11.1.tgz",
-      "integrity": "sha512-rXE9oMFGMtdQrixnumWYH5TTGsp99iPHZb3jI74YWq518ctCh6DlIgWlhf6ok2X0+lhWovcIb45KJucUFAQ13w==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-base/-/publisher-base-7.11.2.tgz",
+      "integrity": "sha512-YwK4ZF3+uW7PBEV/ho59NVTriP3fCahskORrztUaFIdG0QP3hqMsfmo01euv98FDsBEW9UXo7/EW8t5jpmYZ0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.11.1"
+        "@electron-forge/shared-types": "7.11.2"
       },
       "engines": {
         "node": ">= 16.4.0"
       }
     },
     "node_modules/@electron-forge/shared-types": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.11.1.tgz",
-      "integrity": "sha512-vvBWdAEh53UJlDGUevpaJk1+sqDMQibfrbHR+0IPA4MPyQex7/Uhv3vYH9oGHujBVAChQahjAuJt0fG6IJBLZg==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.11.2.tgz",
+      "integrity": "sha512-Tcles7y74xy3jN5dEC+Pt1duJYk4c7W2xu98tjWW8RewmfKD2uHkie6I1I3yifPFZXZ/QfTlaFOOoKIQ9ENZjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/tracer": "7.11.1",
+        "@electron-forge/tracer": "7.11.2",
         "@electron/packager": "^18.3.5",
         "@electron/rebuild": "^3.7.0",
         "listr2": "^7.0.2"
@@ -314,14 +306,14 @@
       }
     },
     "node_modules/@electron-forge/template-base": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-base/-/template-base-7.11.1.tgz",
-      "integrity": "sha512-XpTaEf+EfQw+0BlSAtSpZKYIKYvKu4raNzSGHZZoSYHp+HDC7R+MlpFQmSJiGdYQzQ14C+uxO42tVjgM0DMbpw==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-base/-/template-base-7.11.2.tgz",
+      "integrity": "sha512-l10I+XZRbbxFGiDLMnuXmlOppmLYmimKj6FWjEGUvft4VJFXW2BIDrLIugIGdM1nbrl/0aYjen2xRg0nZlcWzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/core-utils": "7.11.1",
-        "@electron-forge/shared-types": "7.11.1",
+        "@electron-forge/core-utils": "7.11.2",
+        "@electron-forge/shared-types": "7.11.2",
         "@malept/cross-spawn-promise": "^2.0.0",
         "debug": "^4.3.1",
         "fs-extra": "^10.0.0",
@@ -333,14 +325,14 @@
       }
     },
     "node_modules/@electron-forge/template-vite": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-vite/-/template-vite-7.11.1.tgz",
-      "integrity": "sha512-Or8Lxf4awoeUZoMTKJEw5KQDIhqOFs24WhVka3yZXxc6VgVWN79KmYKYM6uM/YMQttmafhsBhY2t1Lxo1WR/ug==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-vite/-/template-vite-7.11.2.tgz",
+      "integrity": "sha512-yFSDSu3IdyNpgLXzrwODSUyaWniHRSZI82gwcXdnJLx7D7DIDLtbx6KzEoy7QBmWZRULO3F7rLsYG+Ur7orvyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.11.1",
-        "@electron-forge/template-base": "7.11.1",
+        "@electron-forge/shared-types": "7.11.2",
+        "@electron-forge/template-base": "7.11.2",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -348,14 +340,14 @@
       }
     },
     "node_modules/@electron-forge/template-vite-typescript": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-vite-typescript/-/template-vite-typescript-7.11.1.tgz",
-      "integrity": "sha512-Us4AHXFb+4z+gXgZImSqMBS63oKnsQWLOhqRg321xiDzu2UcQPlwgWNb4rAEKNVC1e7LXrUNDHuBiTrQkvWXbg==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-vite-typescript/-/template-vite-typescript-7.11.2.tgz",
+      "integrity": "sha512-QvvdmO9Gdv+3aISI9+bBLKPBTyKaucs6HhXxz+IDALcdykIL9wVN0/BrWuwwgbwuw4BiJTyXGSPNXuJ+EWnP6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.11.1",
-        "@electron-forge/template-base": "7.11.1",
+        "@electron-forge/shared-types": "7.11.2",
+        "@electron-forge/template-base": "7.11.2",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -363,14 +355,14 @@
       }
     },
     "node_modules/@electron-forge/template-webpack": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack/-/template-webpack-7.11.1.tgz",
-      "integrity": "sha512-15lbXxi+er461MPk6sbwAOyjofAHwmQjTvxNCiNpaU2naEwbj3t0SlLq/BMr5HxnVOaMmA7+lKV9afkIom+d4Q==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack/-/template-webpack-7.11.2.tgz",
+      "integrity": "sha512-JjG8XIZctrSZvTlii7Hqvt/pHDKigRk4PoLTQCs1TiT05ZWsn40itBm8cbja3L7bfm0ccDd3JTWWOl2G7PhlmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.11.1",
-        "@electron-forge/template-base": "7.11.1",
+        "@electron-forge/shared-types": "7.11.2",
+        "@electron-forge/template-base": "7.11.2",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -378,14 +370,14 @@
       }
     },
     "node_modules/@electron-forge/template-webpack-typescript": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack-typescript/-/template-webpack-typescript-7.11.1.tgz",
-      "integrity": "sha512-6ExfFnFkHBz8rvRFTFg5HVGTC12uJpbVk4q8DVg0R8rhhxhqiVNh8lF2UPtZ2yT2UtGWjXNVlyP3Y3T6q6E3GQ==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack-typescript/-/template-webpack-typescript-7.11.2.tgz",
+      "integrity": "sha512-2lwK+OrCeZgYM8WqsUXJzk94rdF0z/kA7WnAf79U3COEmAAMcFIwJtwF8c/n+52UecP3yrEE70LIGmM1sjGZJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.11.1",
-        "@electron-forge/template-base": "7.11.1",
+        "@electron-forge/shared-types": "7.11.2",
+        "@electron-forge/template-base": "7.11.2",
         "fs-extra": "^10.0.0",
         "typescript": "~5.4.5",
         "webpack": "^5.69.1"
@@ -395,9 +387,9 @@
       }
     },
     "node_modules/@electron-forge/tracer": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.11.1.tgz",
-      "integrity": "sha512-tiB6cglVQFcSw9N8GRwVwZUeB9u0DOx2Mj7aFXBUsFLUYQapvVGv51tUSy/UAW5lvmubGscYIILuVko+II3+NA==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.11.2.tgz",
+      "integrity": "sha512-U8j5Hyj2Zt7I5PciJvPJfmEv69Gb/Da9v+k655z3Jj1cuY0UnToEJ61IhXrzlTYqo+jUKC+fgAjDJ6vltJTS0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -536,7 +528,7 @@
     "node_modules/@electron/node-gyp": {
       "version": "10.2.0-electron.1",
       "resolved": "git+ssh://git@github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2",
-      "integrity": "sha512-4MSBTT8y07YUDqf69/vSh80Hh791epYqGtWHO3zSKhYFwQg+gx9wi1PqbqP6YqC4WMsNxZ5l9oDmnWdK5pfCKQ==",
+      "integrity": "sha512-CrYo6TntjpoMO1SHjl5Pa/JoUsECNqNdB7Kx49WLQpWzPw53eEITJ2Hs9fh/ryUYDn4pxZz11StaBYBrLFJdqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -559,9 +551,9 @@
       }
     },
     "node_modules/@electron/node-gyp/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -695,9 +687,9 @@
       }
     },
     "node_modules/@electron/packager/node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -758,9 +750,9 @@
       }
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -768,9 +760,9 @@
       }
     },
     "node_modules/@electron/universal/node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -819,9 +811,9 @@
       }
     },
     "node_modules/@electron/windows-sign/node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1376,45 +1368,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@npmcli/agent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-3.0.0.tgz",
-      "integrity": "sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.1",
-        "lru-cache": "^10.0.1",
-        "socks-proxy-agent": "^8.0.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/@npmcli/agent/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@npmcli/agent/node_modules/socks-proxy-agent": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/@npmcli/fs": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
@@ -1482,9 +1435,9 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1516,41 +1469,19 @@
       }
     },
     "node_modules/@types/debug": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
       }
     },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
-    },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1606,9 +1537,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1834,13 +1765,13 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.6"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -1944,9 +1875,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1979,9 +1910,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2114,31 +2045,34 @@
       }
     },
     "node_modules/app-builder-lib/node_modules/@electron/rebuild": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.3.tgz",
-      "integrity": "sha512-u9vpTHRMkOYCs/1FLiSVAFZ7FbjsXK+bQuzviJZa+lG7BHZl1nz52/IcGvwa3sk80/fc3llutBkbCq10Vh8WQA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.4.tgz",
+      "integrity": "sha512-Rzc39XPdk/+/wBG8MfwAHohXflep0ITUfulb6Rgz3R0NeSB1noE+E9/M/cb8ftCAiyDD9PPhLuuWgE1GaInbKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@malept/cross-spawn-promise": "^2.0.0",
         "debug": "^4.1.1",
-        "detect-libc": "^2.0.1",
-        "got": "^11.7.0",
-        "graceful-fs": "^4.2.11",
         "node-abi": "^4.2.0",
         "node-api-version": "^0.2.1",
-        "node-gyp": "^11.2.0",
-        "ora": "^5.1.0",
-        "read-binary-file-arch": "^1.0.6",
-        "semver": "^7.3.5",
-        "tar": "^7.5.6",
-        "yargs": "^17.0.1"
+        "node-gyp": "^12.2.0",
+        "read-binary-file-arch": "^1.0.6"
       },
       "bin": {
         "electron-rebuild": "lib/cli.js"
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/app-builder-lib/node_modules/balanced-match": {
@@ -2152,9 +2086,9 @@
       }
     },
     "node_modules/app-builder-lib/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2198,13 +2132,13 @@
       }
     },
     "node_modules/app-builder-lib/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2237,9 +2171,9 @@
       }
     },
     "node_modules/app-builder-lib/node_modules/node-abi": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.26.0.tgz",
-      "integrity": "sha512-8QwIZqikRvDIkXS2S93LjzhsSPJuIbfaMETWH+Bx8oOT9Sa9UsUtBFQlc3gBNd1+QINjaTloitXr1W3dQLi9Iw==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.31.0.tgz",
+      "integrity": "sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2264,6 +2198,21 @@
         "url": "https://github.com/sponsors/jet2jet"
       }
     },
+    "node_modules/app-builder-lib/node_modules/plist": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+      "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
     "node_modules/app-builder-lib/node_modules/resedit": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
@@ -2282,10 +2231,23 @@
         "url": "https://github.com/sponsors/jet2jet"
       }
     },
+    "node_modules/app-builder-lib/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/app-builder-lib/node_modules/tar": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz",
-      "integrity": "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==",
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -2541,9 +2503,9 @@
       }
     },
     "node_modules/b4a": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
-      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -2668,9 +2630,9 @@
       }
     },
     "node_modules/bare-events": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
-      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
+      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "bare-abort-controller": "*"
@@ -2682,9 +2644,9 @@
       }
     },
     "node_modules/bare-format": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bare-format/-/bare-format-1.0.1.tgz",
-      "integrity": "sha512-1oS+LZrWK6tnYnvNSHDGljc2MPunRxwhpFriuCgzNF+oklrnwmBKD91tS0yt+jpl2j3UgcSDzBIMiVTvLs9A8w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bare-format/-/bare-format-1.0.2.tgz",
+      "integrity": "sha512-GswdhnOnP9QtwRbrf4wLApw5widkaLMsLe2XOs35fQD2YfEN1ApoGka+cZ7PfvzxMgfYXmMhj/2OGlVn5/Dxgw==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -2693,9 +2655,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.5.tgz",
-      "integrity": "sha512-XvwYM6VZqKoqDll8BmSww5luA5eflDzY0uEFfBJtFKe4PAAtxBjU3YIxzIBzhyaEQBy1VXEQBto4cpN5RZJw+w==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -2738,9 +2700,9 @@
       }
     },
     "node_modules/bare-module": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/bare-module/-/bare-module-6.1.3.tgz",
-      "integrity": "sha512-5XWsVHsvtWMH4tK4DQWgpNTV0t/sg3ZrAaQLIxrwjrS5+u8Q9vEgc/zQ4QaDPWDse/y/5h+d+YG1Q0JfSMt0zA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/bare-module/-/bare-module-6.2.0.tgz",
+      "integrity": "sha512-CoCTG8y8HKPnNW317OW1hynl28DasVPtbX033ZEAXk0Q3SYCUXi3OOnNAr6wTrDgMgpOsW0kl7Nifcom5GGH8Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-bundle": "^1.3.0",
@@ -2779,9 +2741,9 @@
       }
     },
     "node_modules/bare-module-resolve": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.1.tgz",
-      "integrity": "sha512-hbmAPyFpEq8FoZMd5sFO3u6MC5feluWoGE8YKlA8fCrl6mNtx68Wjg4DTiDJcqRJaovTvOYKfYngoBUnbaT7eg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.2.tgz",
+      "integrity": "sha512-j+hiD5k99qec4KjJvYsI67q5AOBifmy9JG3oeMVxTmvrhn2sIdp8StrUvZu4YNgwTpO+NhniQG16N1ETDe1k5w==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-semver": "^1.0.0"
@@ -2796,9 +2758,9 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.7.1.tgz",
-      "integrity": "sha512-ebvMaS5BgZKmJlvuWh14dg9rbUI84QeV3WlWn6Ph6lFI8jJoh7ADtVTyD2c93euwbe+zgi0DVrl4YmqXeM9aIA==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
       "license": "Apache-2.0",
       "engines": {
         "bare": ">=1.14.0"
@@ -2814,9 +2776,9 @@
       }
     },
     "node_modules/bare-pipe": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/bare-pipe/-/bare-pipe-4.1.3.tgz",
-      "integrity": "sha512-DqQsx93rAzre6yJ9T6l/Vgh+X+bntkVMB1X5ggtXjXtqtMmF2Y2RVlCzxxy/09R6yeR9FSWBEUIaMYJL1/5VDA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/bare-pipe/-/bare-pipe-4.1.5.tgz",
+      "integrity": "sha512-6OfxaG8JSkRh3Gc4hzHRsxNt+yu2PpN7lrv1V+T78GdknWQkVGwiEvu4m+1nbfk8cMVQ0TGxRvQ90XA4rhnTuw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.0.0",
@@ -2827,9 +2789,9 @@
       }
     },
     "node_modules/bare-process": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/bare-process/-/bare-process-4.3.0.tgz",
-      "integrity": "sha512-HwtAdKbqS98V+jeWAagUdzkrJR4vtuPeeWlsoeD1YKTqM1hKUWM2eU+l2diUYeTqFfxY9b6J9SsBLuBukH0tMQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/bare-process/-/bare-process-4.4.1.tgz",
+      "integrity": "sha512-JfcTtymq6akqM2bdyTsP4A4GYJceBzb91k/ECmFps75uFf6uO33SM1bOZsRAqyRXExabsQJLn5S41NBl8HTM4A==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -2839,15 +2801,14 @@
         "bare-events": "^2.3.1",
         "bare-hrtime": "^2.0.0",
         "bare-os": "^3.7.1",
-        "bare-pipe": "^4.0.0",
         "bare-signals": "^4.0.0",
-        "bare-tty": "^5.0.0"
+        "bare-stdio": "^1.0.1"
       }
     },
     "node_modules/bare-semver": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.0.2.tgz",
-      "integrity": "sha512-ESVaN2nzWhcI5tf3Zzcq9aqCZ676VWzqw07eEZ0qxAcEOAFYBa0pWq8sK34OQeHLY3JsfKXZS9mDyzyxGjeLzA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.0.3.tgz",
+      "integrity": "sha512-HS/A30bi2+PiRJfU6R4+Kp+6KeLSCSByjYM2iiobOKzLAvtu1CT+S8xWfiU7wz0erknjkUoC+yXy108tzIuP5Q==",
       "license": "Apache-2.0"
     },
     "node_modules/bare-sidecar": {
@@ -2906,20 +2867,37 @@
         "bare": ">=1.7.0"
       }
     },
+    "node_modules/bare-stdio": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bare-stdio/-/bare-stdio-1.0.2.tgz",
+      "integrity": "sha512-3WJDqtvVGP4f+j68kyEC05umOYNwKJ1xG+YAXL8yZ605WgNqiRhVaFq+mVIhBt2eKNp7pa5vCQdhOt1pNh79SA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-fs": "^4.5.2",
+        "bare-pipe": "^4.1.5",
+        "bare-tty": "^5.0.3"
+      }
+    },
     "node_modules/bare-stream": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.8.0.tgz",
-      "integrity": "sha512-reUN0M2sHRqCdG4lUK3Fw8w98eeUIZHL5c3H7Mbhk2yVBL+oofgaIp0ieLfD5QXwPCypBpmEEKU2WZKzbAk8GA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "streamx": "^2.21.0",
+        "streamx": "^2.25.0",
         "teex": "^1.0.1"
       },
       "peerDependencies": {
+        "bare-abort-controller": "*",
         "bare-buffer": "*",
         "bare-events": "*"
       },
       "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
         "bare-buffer": {
           "optional": true
         },
@@ -2928,10 +2906,22 @@
         }
       }
     },
+    "node_modules/bare-stylize": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/bare-stylize/-/bare-stylize-0.0.1.tgz",
+      "integrity": "sha512-l3MjmIl476bWijYWf3RbE+osl4iuXSOMudzp0vAqzIK7gPgn/+G3oAxp8Oin9CFF911KBP0LO9kts8Ci8mGZaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-ansi-escapes": "^2.2.3",
+        "bare-process": "^4.2.1"
+      }
+    },
     "node_modules/bare-subprocess": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/bare-subprocess/-/bare-subprocess-5.2.2.tgz",
-      "integrity": "sha512-L6oXgQ1aWs25RtG5Ky0bDD06p3RAcVVrDDMWb1DfXpHtyEWxamcyIWUbSykxMTWrpLlmSj6ytbb6yoKehGFfmw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bare-subprocess/-/bare-subprocess-5.2.3.tgz",
+      "integrity": "sha512-07wwswlV7M3sC9IykbZRZ/jHAkrXFWVLqdBWGv1y0ojCimtRD9hGwxdHmR5FUFmDUZLNsBmTYJNQqgio5+A85Q==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -2955,9 +2945,9 @@
       }
     },
     "node_modules/bare-tty": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/bare-tty/-/bare-tty-5.0.3.tgz",
-      "integrity": "sha512-jW24RBWRZOMHuSEWC9mh8wUKO5WUNl0UWUTNPn3yZ8qkOqwa8vaV2dR3a+BvblONPk7V35wuvK9P8508+judAg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bare-tty/-/bare-tty-5.1.0.tgz",
+      "integrity": "sha512-EZLvW4A+XiJgI3TW+e1pMME9PIJsfEXe/DA/WSKzIkq/v7Yarpv/rvG6Z5pGnpo4V/Bd+qopwnCLSR71hMMBYA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -2980,18 +2970,18 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
-      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0"
       }
     },
     "node_modules/bare-utils": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/bare-utils/-/bare-utils-1.5.1.tgz",
-      "integrity": "sha512-mxCkFvmDU3mlD/mb+pT64kKXOsx2KMsWLQbngN1LB+NOXfhfnRnyvpy3VZc6m7gzQxe57Bsi+aTCBqA4/S3elQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/bare-utils/-/bare-utils-1.6.0.tgz",
+      "integrity": "sha512-WhQEIkkAxkSnW7u1QgrI0AfNm5JpMruETXeYsb5qnkBJ0TTfNKygZmsh6rkoHBANaV+C/7Jed7bJP9OmEHG7rQ==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -3000,6 +2990,7 @@
         "bare-encoding": "^1.0.0",
         "bare-format": "^1.0.0",
         "bare-inspect": "^3.0.0",
+        "bare-stylize": "^0.0.1",
         "bare-type": "^1.0.6"
       }
     },
@@ -3036,9 +3027,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.10.31",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
+      "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3085,15 +3076,15 @@
       }
     },
     "node_modules/blind-relay": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/blind-relay/-/blind-relay-1.4.0.tgz",
-      "integrity": "sha512-6xt7fDfCs6eGmNNym6I9N42jmjcMQn2qwwOVnkP9ZnrkXFk6c4/tdO1xqRmDEzKzV8gigd+DVdCUG/RUYnen7Q==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/blind-relay/-/blind-relay-1.6.1.tgz",
+      "integrity": "sha512-38YmKCl/m9NcTkwueBbcGIt9Zx3IT/Q9Nsluu6C5Gur6PqfE0zWPhPwCzia1hri/g0ICYxrqkgLtEaoWD5WeSQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4",
         "bare-events": "^2.2.0",
         "bits-to-bytes": "^1.3.0",
-        "compact-encoding": "^2.12.0",
+        "compact-encoding": "^3.0.0",
         "compact-encoding-bitfield": "^1.0.0",
         "protomux": "^3.5.1",
         "sodium-universal": "^5.0.0",
@@ -3118,12 +3109,12 @@
       }
     },
     "node_modules/bogon": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/bogon/-/bogon-1.2.0.tgz",
-      "integrity": "sha512-FqOBr/1VMzCOsoJd+fzNUMarUYki2+TKt07A2+xaulsNx4r53iJ7MV5k0jbqg7W2U0CsLqxCZOrFibdG6h6HSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bogon/-/bogon-1.3.0.tgz",
+      "integrity": "sha512-04tu0G/v0f2HPuQlSfhO635WwHDBCaITJ490rhxH9ttUlgPqOirZVKV02YB6NvPf5VkmbqJCm3bnZwrPk/eDSg==",
       "license": "MIT",
       "dependencies": {
-        "compact-encoding": "^2.11.0",
+        "compact-encoding": "^3.0.0",
         "compact-encoding-net": "^1.2.0"
       }
     },
@@ -3148,9 +3139,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3172,9 +3163,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -3192,11 +3183,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3317,9 +3308,9 @@
       }
     },
     "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3430,9 +3421,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001777",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
-      "integrity": "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "dev": true,
       "funding": [
         {
@@ -3711,30 +3702,30 @@
       }
     },
     "node_modules/compact-encoding": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-2.19.0.tgz",
-      "integrity": "sha512-bPQlzwxgzsuOp0wB6G9TVoZ2tGFANJckQfM10xLKUS2fbLe+fFZG6Gi1wYehcMMTcjvtil8oOJSsToMOlCSu4g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-3.1.0.tgz",
+      "integrity": "sha512-HcXBKXucAr+rqCAzS+SmOgqXXkvbrUqLrqc4FSBGQ6Ifh8SCVTDiIcSfML92ZGK1ARePJIyug0698gnmaAwlBw==",
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.3.0"
       }
     },
     "node_modules/compact-encoding-bitfield": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/compact-encoding-bitfield/-/compact-encoding-bitfield-1.0.0.tgz",
-      "integrity": "sha512-3nMVKUg+PF72UHfainmCL8uKvyWfxsjqOtUY+HiMPGLPCTjnwzoKfFAMo1Ad7nwTPdjBqtGK5b3BOFTFW4EBTg==",
-      "license": "ISC",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding-bitfield/-/compact-encoding-bitfield-1.1.0.tgz",
+      "integrity": "sha512-F6wliSKHi50BsBStmnsRJAzJgYSIYzdfSe3M0oHj4uQ1RcctJK/NQVD7wF51bj/DBMne2i5gUxrGUFkNZQns5w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "compact-encoding": "^2.4.1"
+        "compact-encoding": "^3.0.0"
       }
     },
     "node_modules/compact-encoding-net": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/compact-encoding-net/-/compact-encoding-net-1.2.0.tgz",
-      "integrity": "sha512-LVXpNpF7PGQeHRVVLGgYWzuVoYAaDZvKUsUxRioGfkotzvOh4AzoQF1HBH3zMNaSnx7gJXuUr3hkjnijaH/Eng==",
-      "license": "ISC",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/compact-encoding-net/-/compact-encoding-net-1.3.0.tgz",
+      "integrity": "sha512-HIYjL3aMiSENApR691aMLngXt6rkTHb9HUkEukcx3YwIZpoMUVXHXyjBzoo9kVwC7KakooBA1RRWb46Cu6qtAQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "compact-encoding": "^2.4.1"
+        "compact-encoding": "^3.0.0"
       }
     },
     "node_modules/compare-version": {
@@ -4122,15 +4113,15 @@
       }
     },
     "node_modules/dht-rpc": {
-      "version": "6.26.3",
-      "resolved": "https://registry.npmjs.org/dht-rpc/-/dht-rpc-6.26.3.tgz",
-      "integrity": "sha512-KuLfRv/hecUHipQcTXHpVv4/N4Jhpww5sLdsrn3Edm5oHwzK9SgNV34hNt7a2aVZCOcG5SfP4AvcQ7pI+y9YNg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/dht-rpc/-/dht-rpc-6.27.0.tgz",
+      "integrity": "sha512-NsfgRlFDQnkA2+H+hJXMPLmBOn/TSIIc0cRMV8q42M4xc1uAXWtpvIIQsONF5tYcYC6px0bslrUGideN1h4S4A==",
       "license": "MIT",
       "dependencies": {
         "adaptive-timeout": "^1.0.1",
         "b4a": "^1.6.1",
         "bare-events": "^2.2.0",
-        "compact-encoding": "^2.11.0",
+        "compact-encoding": "^3.0.0",
         "compact-encoding-net": "^1.2.0",
         "fast-fifo": "^1.1.0",
         "kademlia-routing-table": "^1.0.1",
@@ -4279,9 +4270,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "40.8.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-40.8.0.tgz",
-      "integrity": "sha512-WoPq0Nr9Yx3g7T6VnJXdwa/rr2+VRyH3a+K+ezfMKBlf6WjxE/LmhMQabKbb6yjm9RbZhJBRcYyoLph421O2mQ==",
+      "version": "40.10.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-40.10.1.tgz",
+      "integrity": "sha512-F2Iy16vLBV4NodRVf2dGRESUW03AdFlCmOjaF1fhc3FupmTwEGWmKsYXvORkUYLPBSrKP7r08e8PHiImoe8woQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -4702,9 +4693,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.307",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
-      "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
+      "version": "1.5.360",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.360.tgz",
+      "integrity": "sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4738,9 +4729,9 @@
       }
     },
     "node_modules/electron-windows-msix/node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4835,9 +4826,9 @@
       }
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "24.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4933,14 +4924,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
-      "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -4994,9 +4985,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5106,6 +5097,19 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/eta": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-3.5.0.tgz",
+      "integrity": "sha512-e3x3FBvGzeCIHhF+zhK8FZA2vC5uFn6b4HJjegUbIWrDb4mJ7JjTGMJY9VGIbRVpmSwHopNiaJibhjIr+HfLug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/eta-dev/eta?sponsor=1"
       }
     },
     "node_modules/eventemitter3": {
@@ -5355,9 +5359,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -5414,9 +5418,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5596,9 +5600,9 @@
       }
     },
     "node_modules/fs-native-extensions": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/fs-native-extensions/-/fs-native-extensions-1.4.5.tgz",
-      "integrity": "sha512-ekV0T//iDm4AvhOcuPaHpxub4DI7HvY5ucLJVDvi7T2J+NZkQ9S6MuvgP0yeQvoqNUaAGyLjVYb1905BF9bpmg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/fs-native-extensions/-/fs-native-extensions-1.5.0.tgz",
+      "integrity": "sha512-nuZLFm9mGCxvyi7Llww/J4OyifKCS21nEUTAmnlTZp3FObPOvA32aCedCmt4Z+8yk+caqfClNaSCfn/P7T7FLQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "require-addon": "^1.1.0",
@@ -5712,12 +5716,10 @@
       }
     },
     "node_modules/generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-2.0.0.tgz",
+      "integrity": "sha512-KwuURPyqn2Mz8DdV29pJwQu0Y7tcsbkULr82eeOcY/ZllFK6I9Wm8dsRByIu7CKWlFi9BdW1b3mcXMp/kQBQsw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "is-property": "^1.0.0"
       }
@@ -6040,9 +6042,9 @@
       "license": "ISC"
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6145,14 +6147,14 @@
       }
     },
     "node_modules/hyperblobs": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/hyperblobs/-/hyperblobs-2.9.0.tgz",
-      "integrity": "sha512-kbJV2+QvXIcFejqOj2UgSjeeHMjWqP1n083vcI+j4E93MhV3oVV2L8/6X+K/id/KQrUmngPTzNTHHXKlkb1CEA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/hyperblobs/-/hyperblobs-2.12.0.tgz",
+      "integrity": "sha512-yt5plkXaDS8NmuNsdmeud4NbLjKHTnQO619d2EZB9L+wU7X3Ikqh7OBY6i3Lf8iFB1nkob7x8nBlB8x8RPBJZQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.1",
         "bare-events": "^2.5.0",
-        "compact-encoding": "^2.18.0",
+        "compact-encoding": "^3.0.0",
         "hypercore-crypto": "^3.6.1",
         "hypercore-errors": "^1.1.1",
         "mutexify": "^1.4.0",
@@ -6161,22 +6163,22 @@
       }
     },
     "node_modules/hypercore": {
-      "version": "11.27.12",
-      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-11.27.12.tgz",
-      "integrity": "sha512-q8KJnrXu5eqLyN3hD0nScNli5URVUmXOmBvub/wpVeJNkaQwU2C1nIFwFSBzqb1tNf7vZGLj08JfB0K8wH9Zgg==",
+      "version": "11.30.2",
+      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-11.30.2.tgz",
+      "integrity": "sha512-Kfiv96gDJrkq3uT59Yvzw9yIkYRqCQUxoD59e/qYWplYJ/Msou/nhhujXoLjMNpej/ZKHQSL1rAt92CqHkSduA==",
       "license": "MIT",
       "dependencies": {
         "@hyperswarm/secret-stream": "^6.0.0",
         "b4a": "^1.1.0",
         "bare-events": "^2.2.0",
         "big-sparse-array": "^1.0.3",
-        "compact-encoding": "^2.11.0",
+        "compact-encoding": "^3.0.0",
         "fast-fifo": "^1.3.0",
         "flat-tree": "^1.9.0",
         "hypercore-crypto": "^3.2.1",
         "hypercore-errors": "^1.5.0",
         "hypercore-id-encoding": "^1.2.0",
-        "hypercore-storage": "^2.0.0",
+        "hypercore-storage": "^2.8.0",
         "is-options": "^1.0.1",
         "nanoassert": "^2.0.0",
         "protomux": "^3.5.0",
@@ -6190,13 +6192,13 @@
       }
     },
     "node_modules/hypercore-crypto": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/hypercore-crypto/-/hypercore-crypto-3.6.1.tgz",
-      "integrity": "sha512-ltIz2uDwy9pO/ZGTvqcjzyBkvt6O4cVm4r/nNxh0GFs/RbQtqP/i4wCvLEdmU7ptgtnw7fI67WYD1aHPuv4OVA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/hypercore-crypto/-/hypercore-crypto-3.7.0.tgz",
+      "integrity": "sha512-SWxobptQf2V/+ZLCCDRTXqFzGfTPIkNIuDyLKXpEMfcpJ1/ec94N9aWgylHcWOHmRt14ng/KR7z0BugebWHK9Q==",
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.6",
-        "compact-encoding": "^2.15.0",
+        "compact-encoding": "^3.0.0",
         "sodium-universal": "^5.0.0"
       }
     },
@@ -6220,15 +6222,15 @@
       }
     },
     "node_modules/hypercore-storage": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/hypercore-storage/-/hypercore-storage-2.7.0.tgz",
-      "integrity": "sha512-Pp3EHJu7/n2++44VNG2LKGYh0g6tOL472xLzJJNpEIl012gw7Uogbwm0w98GW80N8+OF1yHMkk3HYL+nbpmtbg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/hypercore-storage/-/hypercore-storage-2.9.0.tgz",
+      "integrity": "sha512-MhufmceSHdst+wwysLg5ygSpsB75PiN8U5E1q1SYkAePVHiYbb4dEvKv4d9IyZRrJTBlqcWUEYf7oVosAixi9g==",
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.7",
         "bare-fs": "^4.0.1",
         "bare-path": "^3.0.0",
-        "compact-encoding": "^2.16.0",
+        "compact-encoding": "^3.0.0",
         "device-file": "^2.1.2",
         "flat-tree": "^1.12.1",
         "hypercore-crypto": "^3.4.2",
@@ -6241,9 +6243,9 @@
       }
     },
     "node_modules/hyperdht": {
-      "version": "6.29.1",
-      "resolved": "https://registry.npmjs.org/hyperdht/-/hyperdht-6.29.1.tgz",
-      "integrity": "sha512-V7jkUew1wAur/PfTyiB/y7jTzFAOpqF7pPnlicTJ9m7yA6Iq1O6PDjzjqkRayN/k43jtoOnMwI3Bpg5t1PZYmQ==",
+      "version": "6.32.0",
+      "resolved": "https://registry.npmjs.org/hyperdht/-/hyperdht-6.32.0.tgz",
+      "integrity": "sha512-Y/SibEN7wue0E8ydh8lx9IX7SOE9o00b6tufPA7hRxAafXsisWUBrW36fIHdyxg148T4Z3olrooOGZDZ89LYag==",
       "license": "MIT",
       "dependencies": {
         "@hyperswarm/secret-stream": "^6.6.2",
@@ -6251,11 +6253,11 @@
         "bare-events": "^2.2.0",
         "blind-relay": "^1.3.0",
         "bogon": "^1.0.0",
-        "compact-encoding": "^2.4.1",
-        "compact-encoding-net": "^1.0.1",
+        "compact-encoding": "^3.0.0",
         "dht-rpc": "^6.15.1",
         "hypercore-crypto": "^3.3.0",
         "hypercore-id-encoding": "^1.2.0",
+        "hyperdht-address": "^1.0.1",
         "noise-curve-ed": "^2.0.0",
         "noise-handshake": "^4.0.0",
         "record-cache": "^1.1.1",
@@ -6270,10 +6272,20 @@
         "hyperdht": "bin.js"
       }
     },
+    "node_modules/hyperdht-address": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hyperdht-address/-/hyperdht-address-1.1.1.tgz",
+      "integrity": "sha512-Mu/+7SW2cwvHxMXswa5mOrhrS5BJyntViAuB25k8d8wNtA8eAPs4LaIq6TwN1SS/KQY02h1r+gM8cQeN/k360w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "compact-encoding": "^3.0.0",
+        "hyperschema": "^1.20.1"
+      }
+    },
     "node_modules/hyperdrive": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/hyperdrive/-/hyperdrive-13.3.0.tgz",
-      "integrity": "sha512-6FQXLE4gARRdrlDck0oeAm0Rz0QRi1x2QWP/FdVCAqlAjHjvHfCMf3M+CeO6HcAyI8GuFN3C9HJm80ytR2dzSg==",
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/hyperdrive/-/hyperdrive-13.3.2.tgz",
+      "integrity": "sha512-YgM/be3hppRTLN7plGGot30w58imhCBhzy+bfSToyDH0Gf4ykwplOxsW3YnDIIH5Oa/tNU2ZdZHQ6IhrTZ9aLQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "hyperbee": "^2.11.1",
@@ -6291,24 +6303,15 @@
       }
     },
     "node_modules/hyperschema": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/hyperschema/-/hyperschema-1.20.1.tgz",
-      "integrity": "sha512-7gnvaTNUs8FqdrU3NNE6nzhOneGyDlUlpROu9YFlHA61fE8ppKKf2gLZjZjsx/enNt+VFN4ITxy8ijypfyWBLw==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/hyperschema/-/hyperschema-1.21.0.tgz",
+      "integrity": "sha512-lEnIbLTUQf7w6FU6X+R3yUJhBwCzF4ewRnAaYOrPdcVWe1rbOf94PzMiXb5pBKxroCXzlrPLxVujxAsTrrHc8g==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-fs": "^4.0.1",
-        "compact-encoding": "^2.19.0",
+        "compact-encoding": "^3.0.0",
         "generate-object-property": "^2.0.0",
         "generate-string": "^1.0.1"
-      }
-    },
-    "node_modules/hyperschema/node_modules/generate-object-property": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-2.0.0.tgz",
-      "integrity": "sha512-KwuURPyqn2Mz8DdV29pJwQu0Y7tcsbkULr82eeOcY/ZllFK6I9Wm8dsRByIu7CKWlFi9BdW1b3mcXMp/kQBQsw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-property": "^1.0.0"
       }
     },
     "node_modules/hyperswarm": {
@@ -6480,9 +6483,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6526,13 +6529,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6612,6 +6615,17 @@
         "is-my-ip-valid": "^1.0.0",
         "jsonpointer": "^5.0.0",
         "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/is-my-json-valid/node_modules/generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-property": "^1.0.0"
       }
     },
     "node_modules/is-number": {
@@ -6763,9 +6777,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6789,13 +6803,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -6828,9 +6835,9 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7104,9 +7111,9 @@
       }
     },
     "node_modules/loader-runner": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
-      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+      "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7149,9 +7156,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -7408,9 +7415,9 @@
       }
     },
     "node_modules/lunte": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/lunte/-/lunte-1.6.0.tgz",
-      "integrity": "sha512-8rKBwGPp5PukMy3zT6H6VRiVlx5AyyslOv7+h/FiUS5T2WCrGDBSY6SMHiuNMS/hlHSmoBLjZbx9XmEp/nd7Aw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lunte/-/lunte-1.8.0.tgz",
+      "integrity": "sha512-znc/elScelBYq/N6hUngr9rPdArBKhn4yR86ofnuj6qQ0MAHAo8KalAY2c/DBKw3dO4FjUZ9PR+YCFSbCgBcWQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7421,7 +7428,7 @@
       },
       "optionalDependencies": {
         "bare-events": "^2.8.1",
-        "bare-fs": "^4.5.0",
+        "bare-fs": "^4.7.0",
         "bare-module": "^6.1.2",
         "bare-os": "^3.6.2",
         "bare-path": "^3.0.0",
@@ -7733,11 +7740,11 @@
       }
     },
     "node_modules/minipass-flush": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -7786,9 +7793,9 @@
       }
     },
     "node_modules/mirror-drive": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/mirror-drive/-/mirror-drive-1.13.0.tgz",
-      "integrity": "sha512-dwf2eIaeFgzv03hfW4aCQ/smNIGuxbsnNRrdGAGIyS70Hp0lbOoHXce2V34hGCoxmzn7jeLA4bHJiWlfKOu2Sg==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/mirror-drive/-/mirror-drive-1.14.2.tgz",
+      "integrity": "sha512-1ZtS/TonGXWX0eDAGK90JapGyzOaz8IxX7mARZWPgUuZ9eEIvaoSY7bxv6/4FOW26wL8g/YcpqJpt8mMZ/QZCA==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.8.2",
@@ -7821,9 +7828,9 @@
       "license": "MIT"
     },
     "node_modules/msix-manager": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/msix-manager/-/msix-manager-0.2.3.tgz",
-      "integrity": "sha512-mihLMIQ9C4nEgiwhoG45KzbrGwGBf6p1M3CR4ua+fSq0qVotGuNb7VEBmfeVLCLVkJOohCa0N68QGulLtDz3bQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/msix-manager/-/msix-manager-0.2.5.tgz",
+      "integrity": "sha512-bfAqCBIIoxCsBCuDCr9wCfucmL0fy8jE4GBf9Yx24ZXDxQe4L7r/CJcNcGQxWx9RdHGCqCuNKrrNLfTYOue3fw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.8.2",
@@ -7864,9 +7871,9 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
-      "integrity": "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
+      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
       "dev": true,
       "license": "MIT",
       "optional": true
@@ -7908,9 +7915,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.87.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
-      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7961,85 +7968,38 @@
       }
     },
     "node_modules/node-gyp": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-11.5.0.tgz",
-      "integrity": "sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.3.0.tgz",
+      "integrity": "sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^14.0.3",
-        "nopt": "^8.0.0",
-        "proc-log": "^5.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "tar": "^7.4.3",
+        "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
-        "which": "^5.0.0"
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
       },
       "bin": {
         "node-gyp": "bin/node-gyp.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/@npmcli/fs": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-4.0.0.tgz",
-      "integrity": "sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/node-gyp/node_modules/abbrev": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
-      "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/cacache": {
-      "version": "19.0.1",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-19.0.1.tgz",
-      "integrity": "sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^4.0.0",
-        "fs-minipass": "^3.0.0",
-        "glob": "^10.2.2",
-        "lru-cache": "^10.0.1",
-        "minipass": "^7.0.3",
-        "minipass-collect": "^2.0.1",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "p-map": "^7.0.2",
-        "ssri": "^12.0.0",
-        "tar": "^7.4.3",
-        "unique-filename": "^4.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/node-gyp/node_modules/chownr": {
@@ -8052,95 +8012,14 @@
         "node": ">=18"
       }
     },
-    "node_modules/node-gyp/node_modules/fs-minipass": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
-      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/node-gyp/node_modules/isexe": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
-      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/node-gyp/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/node-gyp/node_modules/make-fetch-happen": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-14.0.3.tgz",
-      "integrity": "sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/agent": "^3.0.0",
-        "cacache": "^19.0.1",
-        "http-cache-semantics": "^4.1.1",
-        "minipass": "^7.0.2",
-        "minipass-fetch": "^4.0.0",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^1.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "ssri": "^12.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": ">=20"
       }
     },
     "node_modules/node-gyp/node_modules/minipass": {
@@ -8151,37 +8030,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/node-gyp/node_modules/minipass-collect": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
-      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/node-gyp/node_modules/minipass-fetch": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-4.0.1.tgz",
-      "integrity": "sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.0.3",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^3.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.13"
       }
     },
     "node_modules/node-gyp/node_modules/minizlib": {
@@ -8197,72 +8045,36 @@
         "node": ">= 18"
       }
     },
-    "node_modules/node-gyp/node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/node-gyp/node_modules/nopt": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
-      "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "abbrev": "^3.0.0"
+        "abbrev": "^4.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/p-map": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/node-gyp/node_modules/proc-log": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
-      "integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/ssri": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
-      "integrity": "sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/node-gyp/node_modules/tar": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz",
-      "integrity": "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==",
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -8276,46 +8088,20 @@
         "node": ">=18"
       }
     },
-    "node_modules/node-gyp/node_modules/unique-filename": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-4.0.0.tgz",
-      "integrity": "sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/unique-slug": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-5.0.0.tgz",
-      "integrity": "sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
     "node_modules/node-gyp/node_modules/which": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "isexe": "^3.1.1"
+        "isexe": "^4.0.0"
       },
       "bin": {
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/node-gyp/node_modules/yallist": {
@@ -8329,11 +8115,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.45",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.45.tgz",
+      "integrity": "sha512-iIbHXV9eBB2nB0wa7oTsrrXq+qQt+9SIlx9AX3T96YgobtEQfis5n6TJ6vV+3QP8DwdriEAcGhARaFCu37peBg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/noise-curve-ed": {
       "version": "2.1.0",
@@ -8678,9 +8467,9 @@
       "license": "BlueOak-1.0.0"
     },
     "node_modules/paparam": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/paparam/-/paparam-1.10.0.tgz",
-      "integrity": "sha512-p36QQrwU3X6fj5d2JN20B4lcZI/O3fxMVUHc1xD7MNe5bcOf3jIgE0CIK5Zv/s5YAUGlobTJ/kKXrh1FJVrs3w==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/paparam/-/paparam-1.10.1.tgz",
+      "integrity": "sha512-viyQI64VIja0Za3njIzhoEP8ZVkgPowhZPuG0E96NwBfYJ6ZIyrrlhWGtFPkdN7eYLl2L8CTWL+wla0evm1KKQ==",
       "license": "Apache-2.0"
     },
     "node_modules/parse-author": {
@@ -9297,18 +9086,20 @@
       }
     },
     "node_modules/pear-runtime-updater": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pear-runtime-updater/-/pear-runtime-updater-3.0.0.tgz",
-      "integrity": "sha512-obpQKBxbHCK8lIzRhRRZ8e8ievwxmZt5HXGD8r0GCv5ls3LK0OU8QQPMKTAzOCZ2HPVeDbZ0SbeveumT5Dd2Vw==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/pear-runtime-updater/-/pear-runtime-updater-3.0.11.tgz",
+      "integrity": "sha512-kBPBs59HBx0ObfphI+3VkIKDmLZJe0DzSborfIu2gpls7o/PttvMnLj2ffHtUcaJTCy+h2vRSfYt1Qcmutfd0w==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-fs": "^4.5.3",
         "bare-path": "^3.0.0",
+        "bare-semver": "^1.0.2",
+        "debounceify": "^1.1.0",
         "fs-native-extensions": "^1.4.5",
         "hypercore-id-encoding": "^1.3.0",
         "hyperdrive": "^13.2.1",
         "localdrive": "^2.2.0",
-        "msix-manager": "^0.2.1",
+        "msix-manager": "^0.2.4",
         "pear-link": "^4.2.1",
         "ready-resource": "^1.2.0",
         "which-runtime": "^1.3.2"
@@ -9329,9 +9120,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9352,13 +9143,13 @@
       }
     },
     "node_modules/plist": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
-      "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
+      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
+        "@xmldom/xmldom": "^0.9.10",
         "base64-js": "^1.5.1",
         "xmlbuilder": "^15.1.1"
       },
@@ -9393,9 +9184,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -9498,13 +9289,13 @@
       }
     },
     "node_modules/protomux": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/protomux/-/protomux-3.10.1.tgz",
-      "integrity": "sha512-jgBqx8ZyaBWea/DFG4eOu1scOaeBwcnagiRC1XFVrjeGt7oAb0Pk5udPpBUpJ4DJBRjra50jD6YcZiQQTRqaaA==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/protomux/-/protomux-3.11.0.tgz",
+      "integrity": "sha512-Ze43XaNHbL6zQ/zJwVYvue7Aj8pDB1HNnISsrFhAur3291Y+Iu2fMhOpySD73J/32BoBIUYrhl07lJsBR/fUVA==",
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.3.1",
-        "compact-encoding": "^2.5.1",
+        "compact-encoding": "^3.0.0",
         "queue-tick": "^1.0.0",
         "safety-catch": "^1.0.1",
         "unslab": "^1.3.0"
@@ -9905,12 +9696,13 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -10046,12 +9838,12 @@
       }
     },
     "node_modules/rocksdb-native": {
-      "version": "3.13.2",
-      "resolved": "https://registry.npmjs.org/rocksdb-native/-/rocksdb-native-3.13.2.tgz",
-      "integrity": "sha512-FB8gH5eBo+SjqA7uDVGWHe2zlYugF8H775tueWAl+jK26zZvxPP8nXCgs5rZTjMhdBY7wYC2nm3V20pyAKbkcQ==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/rocksdb-native/-/rocksdb-native-3.15.1.tgz",
+      "integrity": "sha512-T9inGQj9pLNxnWeW2hRGGT9+FGGGFqHUSmTzrEClFQRCo4Jg7YWfIwLasWOZy65VPo9BrwCz5ZHFf7n54Kakzw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "compact-encoding": "^2.15.0",
+        "compact-encoding": "^3.0.0",
         "ready-resource": "^1.0.0",
         "refcounter": "^1.0.0",
         "require-addon": "^1.0.2",
@@ -10126,9 +9918,9 @@
       "license": "MIT"
     },
     "node_modules/safety-catch": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/safety-catch/-/safety-catch-1.0.2.tgz",
-      "integrity": "sha512-C1UYVZ4dtbBxEtvOcpjBaaD27nP8MlvyAQEp2fOTOEe6pfUpk1cDUxij6BR1jZup6rSyUTaBBplK7LanskrULA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/safety-catch/-/safety-catch-1.0.3.tgz",
+      "integrity": "sha512-Zq+J1TefpoEq/HTUabo0YXX5MNvttjWYODGohgPBO2jfko8Wqx3JYMgE823szDFVamdH5PlpByvfiWScTdSYDA==",
       "license": "MIT"
     },
     "node_modules/same-data": {
@@ -10138,9 +9930,9 @@
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
       "dev": true,
       "license": "WTFPL OR ISC",
       "dependencies": {
@@ -10148,9 +9940,9 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
-      "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -10178,9 +9970,9 @@
       }
     },
     "node_modules/schema-utils/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10221,9 +10013,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -10391,13 +10183,13 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -10580,9 +10372,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
-      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
@@ -10751,9 +10543,9 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10876,9 +10668,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
-      "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
+      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -10895,9 +10687,9 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.17",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.17.tgz",
-      "integrity": "sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.0.tgz",
+      "integrity": "sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10917,10 +10709,37 @@
         "webpack": "^5.1.0"
       },
       "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
         "@swc/core": {
           "optional": true
         },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
         "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
           "optional": true
         },
         "uglify-js": {
@@ -10985,14 +10804,14 @@
       "optional": true
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -11020,9 +10839,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11187,6 +11006,16 @@
       },
       "engines": {
         "bare": ">=1.17.4"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -11399,13 +11228,12 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
-      "version": "5.105.4",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
-      "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
+      "version": "5.107.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.0.tgz",
+      "integrity": "sha512-PSxeHk/dmLYZlnTU+vL1Gej6Evg5RNtl3flhxBresfznFnzxinHMzHKloHnywM/3ouQv7/AlZCswWDIkNSggUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
         "@webassemblyjs/ast": "^1.14.1",
@@ -11415,21 +11243,20 @@
         "acorn-import-phases": "^1.0.3",
         "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.20.0",
-        "es-module-lexer": "^2.0.0",
+        "enhanced-resolve": "^5.21.4",
+        "es-module-lexer": "^2.1.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.3.1",
-        "mime-types": "^2.1.27",
+        "loader-runner": "^4.3.2",
+        "mime-db": "^1.54.0",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.3.17",
+        "terser-webpack-plugin": "^5.5.0",
         "watchpack": "^2.5.1",
-        "webpack-sources": "^3.3.4"
+        "webpack-sources": "^3.4.1"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -11448,13 +11275,23 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
-      "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.1.tgz",
+      "integrity": "sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/whatwg-url": {
@@ -11485,9 +11322,9 @@
       }
     },
     "node_modules/which-runtime": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/which-runtime/-/which-runtime-1.3.2.tgz",
-      "integrity": "sha512-5kwCfWml7+b2NO7KrLMhYihjRx0teKkd3yGp1Xk5Vaf2JGdSh+rgVhEALAD9c/59dP+YwJHXoEO7e8QPy7gOkw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/which-runtime/-/which-runtime-1.4.0.tgz",
+      "integrity": "sha512-0ugbP4CJW4e2D20jvEcC4973dCgIaHI4Rw1PT+26U9zEve7FyYdWAIwUnoeOYvoCfn+wXHoHTKb1KhkYlb60Pw==",
       "license": "Apache-2.0"
     },
     "node_modules/wide-align": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,11 @@
       "name": "hello-pear-electron",
       "version": "1.0.0",
       "dependencies": {
-        "corestore": "^7.9.1",
+        "bare-path": "^3.0.0",
+        "corestore": "^7.9.2",
         "hyperswarm": "^4.17.0",
         "paparam": "^1.10.0",
-        "pear-runtime": "^1.0.1",
+        "pear-runtime": "^1.1.3",
         "which-runtime": "^1.3.2"
       },
       "devDependencies": {
@@ -2850,9 +2851,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/bare-sidecar": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/bare-sidecar/-/bare-sidecar-0.3.0.tgz",
-      "integrity": "sha512-NyhdUnQLnPQTGCSRGHxLQzq3OPnKTBcK065HDjwO/mnVPpZV/zIdJVIzXY5SMNob9NTHNaYxka25nv6WxcPXEg==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/bare-sidecar/-/bare-sidecar-0.4.5.tgz",
+      "integrity": "sha512-2q5+VxlRiyJ2T/kniAv+oI760ZL8veyrqr9N6Dn0M9iif+Zz6DAUpoVzHyid+hI7NO6Bqb73u30QUvdTUGjBEA==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-fs": "^4.5.1",
@@ -2861,9 +2862,33 @@
         "bare-path": "^3.0.0",
         "bare-pipe": "^4.1.3",
         "bare-stream": "^2.7.0",
-        "bare-subprocess": "^5.1.5",
+        "bare-subprocess": "^6.0.0",
         "bare-url": "^2.3.2",
         "require-asset": "^1.1.0"
+      }
+    },
+    "node_modules/bare-sidecar/node_modules/bare-subprocess": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bare-subprocess/-/bare-subprocess-6.0.0.tgz",
+      "integrity": "sha512-0uIOyxnhX14liHAM54tajLedN5eUsXSmxZOzDkODmuxeU8s/6/jVx5UFHOeAeDSiHHXMFf0BcaszEVsURkWJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-env": "^3.0.0",
+        "bare-events": "^2.5.4",
+        "bare-os": "^3.0.1",
+        "bare-pipe": "^4.0.0",
+        "bare-url": "^2.2.2"
+      },
+      "engines": {
+        "bare": ">=1.7.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
       }
     },
     "node_modules/bare-signals": {
@@ -2907,7 +2932,9 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/bare-subprocess/-/bare-subprocess-5.2.2.tgz",
       "integrity": "sha512-L6oXgQ1aWs25RtG5Ky0bDD06p3RAcVVrDDMWb1DfXpHtyEWxamcyIWUbSykxMTWrpLlmSj6ytbb6yoKehGFfmw==",
+      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "bare-env": "^3.0.0",
         "bare-events": "^2.5.4",
@@ -3829,9 +3856,9 @@
       "peer": true
     },
     "node_modules/corestore": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/corestore/-/corestore-7.9.1.tgz",
-      "integrity": "sha512-iidOmmDozIV+WGSJkbEWEtDe80YQpVvh4p5sgnV40pq8tTeBb05i0grTcFbp2VUGeKl24o+qHD2AKlWeqL35eA==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/corestore/-/corestore-7.9.2.tgz",
+      "integrity": "sha512-dyIktVSVLu0skZ1UM4yODbNbZ46dBpTHypzwlwET1btVuS3YIf66Zz8Tx8h3Xa8nbLO2USGqrYtvPYzSRj2wCA==",
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.7",
@@ -9256,13 +9283,13 @@
       }
     },
     "node_modules/pear-runtime": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pear-runtime/-/pear-runtime-1.0.1.tgz",
-      "integrity": "sha512-3zFm8yc1/ko1uVUc3gC4agRiIBBOQ7+z+yQZQ7q7K/UB85UaquE6jJj89qgSaO/rP1bZt/cWTvh6XTnMOnEM0w==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pear-runtime/-/pear-runtime-1.1.3.tgz",
+      "integrity": "sha512-kBtUACxKslUDXQzHEkdUBI0T4AwnGgwYqogsOnACOscmhpz33U1eSwxxhxfSW1gUXBdnyjradirEexNZ/nj2vg==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0",
-        "bare-sidecar": "^0.3.0",
+        "bare-sidecar": "^0.4.5",
         "corestore": "^7.9.1",
         "hyperswarm": "^4.17.0",
         "pear-runtime-updater": "^3.0.0",
@@ -9827,15 +9854,16 @@
       }
     },
     "node_modules/require-asset": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/require-asset/-/require-asset-1.2.1.tgz",
-      "integrity": "sha512-wFFxOxJHL/agpiXNDMzDBzC8hnmjJZYW0wDgolojZZkydS76talLlIH+DU3DWjBxQcu0vair30H7V3C4FcLnSg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/require-asset/-/require-asset-1.2.2.tgz",
+      "integrity": "sha512-uc8nWKhqAxVD9Z4rST2b4yaemrC9Xb5vA1wlCz5AiCYnBYdwGRWNqFjneA5zRILzlo1MNrB63ry9+pc8wNR26w==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-module-resolve": "^1.6.2"
       },
       "engines": {
-        "bare": ">=1.10.0"
+        "bare": ">=1.10.0",
+        "node": ">=18"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -17,30 +17,28 @@
     "make": "electron-forge make"
   },
   "dependencies": {
-    "bare-path": "^3.0.0",
-    "corestore": "^7.9.2",
-    "graceful-goodbye": "^1.3.3",
+    "corestore": "^7.9.1",
     "hyperswarm": "^4.17.0",
-    "paparam": "^1.10.1",
+    "paparam": "^1.10.0",
     "pear-runtime": "^1.1.4",
-    "which-runtime": "^1.4.0"
+    "which-runtime": "^1.3.2"
   },
   "devDependencies": {
-    "@electron-forge/cli": "^7.11.2",
-    "@electron-forge/maker-deb": "^7.11.2",
-    "@electron-forge/maker-dmg": "^7.11.2",
-    "@electron-forge/maker-msix": "^7.11.2",
-    "@electron-forge/maker-rpm": "^7.11.2",
-    "@electron-forge/maker-zip": "^7.11.2",
+    "@electron-forge/cli": "^7.11.1",
+    "@electron-forge/maker-deb": "^7.11.1",
+    "@electron-forge/maker-dmg": "^7.11.1",
+    "@electron-forge/maker-msix": "^7.11.1",
+    "@electron-forge/maker-rpm": "^7.11.1",
+    "@electron-forge/maker-zip": "^7.11.1",
     "app-builder-lib": "^26.8.1",
-    "electron": "^40.10.1",
-    "electron-forge-plugin-prune-prebuilds": "^1.0.1",
+    "electron": "^40.2.1",
+    "electron-forge-plugin-prune-prebuilds": "^1.0.0",
     "electron-forge-plugin-universal-prebuilds": "^1.0.0",
-    "lunte": "^1.8.0",
+    "lunte": "^1.6.0",
     "pear-electron-forge-maker-appimage": "^2.0.0",
     "pear-electron-forge-maker-flatpak": "^0.0.4",
     "pear-electron-forge-maker-snap": "^0.0.10",
-    "prettier": "^3.8.3",
+    "prettier": "^3.8.1",
     "prettier-config-holepunch": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "corestore": "^7.9.2",
     "hyperswarm": "^4.17.0",
     "paparam": "^1.10.1",
-    "pear-runtime": "^1.1.3",
+    "pear-runtime": "^1.1.4",
     "which-runtime": "^1.4.0"
   },
   "devDependencies": {
@@ -31,14 +31,14 @@
     "@electron-forge/maker-msix": "^7.11.2",
     "@electron-forge/maker-rpm": "^7.11.2",
     "@electron-forge/maker-zip": "^7.11.2",
-    "pear-electron-forge-maker-flatpak": "^0.0.4",
-    "pear-electron-forge-maker-snap": "^0.0.10",
     "app-builder-lib": "^26.8.1",
     "electron": "^40.10.1",
     "electron-forge-plugin-prune-prebuilds": "^1.0.1",
     "electron-forge-plugin-universal-prebuilds": "^1.0.0",
     "lunte": "^1.8.0",
     "pear-electron-forge-maker-appimage": "^2.0.0",
+    "pear-electron-forge-maker-flatpak": "^0.0.4",
+    "pear-electron-forge-maker-snap": "^0.0.10",
     "prettier": "^3.8.3",
     "prettier-config-holepunch": "^2.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "bare-path": "^3.0.0",
     "corestore": "^7.9.2",
+    "graceful-goodbye": "^1.3.3",
     "hyperswarm": "^4.17.0",
     "paparam": "^1.10.1",
     "pear-runtime": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,11 @@
     "make": "electron-forge make"
   },
   "dependencies": {
-    "corestore": "^7.9.1",
+    "bare-path": "^3.0.0",
+    "corestore": "^7.9.2",
     "hyperswarm": "^4.17.0",
     "paparam": "^1.10.0",
-    "pear-runtime": "^1.0.1",
+    "pear-runtime": "^1.1.3",
     "which-runtime": "^1.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   },
   "dependencies": {
     "corestore": "^7.9.1",
+    "framed-stream": "^1.0.1",
+    "graceful-goodbye": "^1.3.3",
     "hyperswarm": "^4.17.0",
     "paparam": "^1.10.0",
     "pear-runtime": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -20,24 +20,24 @@
     "bare-path": "^3.0.0",
     "corestore": "^7.9.2",
     "hyperswarm": "^4.17.0",
-    "paparam": "^1.10.0",
+    "paparam": "^1.10.1",
     "pear-runtime": "^1.1.3",
-    "which-runtime": "^1.3.2"
+    "which-runtime": "^1.4.0"
   },
   "devDependencies": {
-    "@electron-forge/cli": "^7.11.1",
-    "@electron-forge/maker-deb": "^7.11.1",
-    "@electron-forge/maker-dmg": "^7.11.1",
-    "@electron-forge/maker-msix": "^7.11.1",
-    "@electron-forge/maker-rpm": "^7.11.1",
-    "@electron-forge/maker-zip": "^7.11.1",
+    "@electron-forge/cli": "^7.11.2",
+    "@electron-forge/maker-deb": "^7.11.2",
+    "@electron-forge/maker-dmg": "^7.11.2",
+    "@electron-forge/maker-msix": "^7.11.2",
+    "@electron-forge/maker-rpm": "^7.11.2",
+    "@electron-forge/maker-zip": "^7.11.2",
     "app-builder-lib": "^26.8.1",
-    "electron": "^40.2.1",
-    "electron-forge-plugin-prune-prebuilds": "^1.0.0",
+    "electron": "^40.10.1",
+    "electron-forge-plugin-prune-prebuilds": "^1.0.1",
     "electron-forge-plugin-universal-prebuilds": "^1.0.0",
-    "lunte": "^1.6.0",
+    "lunte": "^1.8.0",
     "pear-electron-forge-maker-appimage": "^2.0.0",
-    "prettier": "^3.8.1",
+    "prettier": "^3.8.3",
     "prettier-config-holepunch": "^2.0.0"
   }
 }

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -3,11 +3,7 @@ const decoder = new TextDecoder('utf-8')
 
 document.getElementById('v').innerText += bridge.pkg().version
 
-bridge.onPearEvent('updating', () => {
-  document.getElementById('v').innerText = 'UPDATING...'
-})
-
-bridge.onPearEvent('updated', () => {
+function showUpdateReady() {
   document.getElementById('v').innerText = 'Update ready!'
   const btn = document.getElementById('update-btn')
   btn.style.display = 'inline-block'
@@ -22,13 +18,22 @@ bridge.onPearEvent('updated', () => {
       btn.style.display = 'none'
     }
   }
-})
+}
+
+function onWorkerUpdaterEvent(name) {
+  if (name === 'updating') {
+    document.getElementById('v').innerText = 'UPDATING...'
+    return
+  }
+  if (name === 'updated') showUpdateReady()
+}
 
 const workers = {
   main: '/workers/main.js'
 }
 
 bridge.startWorker(workers.main)
+let sentHello = false
 
 const offWorkerStdout = bridge.onWorkerStdout(workers.main, (data) => {
   console.log('worker stdout', '[', workers.main, ']:', decoder.decode(data))
@@ -39,9 +44,14 @@ const offWorkerStderr = bridge.onWorkerStderr(workers.main, (data) => {
 })
 
 const offWorkerIpc = bridge.onWorkerIPC(workers.main, (data) => {
-  console.log('worker ipc', '[', workers.main, ']:', decoder.decode(data))
+  const message = decoder.decode(data)
+  console.log('worker ipc', '[', workers.main, ']:', message)
+  onWorkerUpdaterEvent(message)
 
-  bridge.writeWorkerIPC(workers.main, 'Hello from renderer')
+  if (!sentHello) {
+    sentHello = true
+    bridge.writeWorkerIPC(workers.main, 'Hello from renderer')
+  }
 })
 
 const offWorkerExit = bridge.onWorkerExit(workers.main, (code) => {

--- a/workers/main.js
+++ b/workers/main.js
@@ -10,7 +10,7 @@ const pipe = new FramedStream(Bare.IPC)
 const updaterConfig = {
   dir: Bare.argv[2],
   app: Bare.argv[3],
-  updates: Bare.argv[4],
+  updates: Bare.argv[4] === 'true',
   version: Bare.argv[5],
   upgrade: Bare.argv[6],
   name: Bare.argv[7]
@@ -19,7 +19,8 @@ const updaterConfig = {
 const store = new Corestore(path.join(updaterConfig.dir, 'pear-runtime/corestore'))
 const swarm = new Hyperswarm()
 const pear = new PearRuntime({ ...updaterConfig, swarm, store })
-pear.on('error', console.log)
+
+pear.updater.on('error', console.error)
 if (updaterConfig.updates !== false) {
   swarm.on('connection', (connection) => store.replicate(connection))
   swarm.join(pear.updater.drive.core.discoveryKey, {

--- a/workers/main.js
+++ b/workers/main.js
@@ -1,13 +1,14 @@
 const PearRuntime = require('pear-runtime')
 const Hyperswarm = require('hyperswarm')
 const Corestore = require('corestore')
+const goodbye = require('graceful-goodbye')
 const path = require('bare-path')
 
 const updaterConfig = JSON.parse(Bare.argv[2])
 
 const store = new Corestore(path.join(updaterConfig.dir, 'pear-runtime/corestore'))
 const swarm = new Hyperswarm()
-const pear = new PearRuntime({...updaterConfig, swarm, store})
+const pear = new PearRuntime({ ...updaterConfig, swarm, store })
 pear.on('error', console.log)
 if (updaterConfig.updates !== false) {
   swarm.on('connection', (connection) => store.replicate(connection))
@@ -20,16 +21,16 @@ if (updaterConfig.updates !== false) {
 pear.updater.on('updating', () => Bare.IPC.write('updating'))
 pear.updater.on('updated', () => Bare.IPC.write('updated'))
 
-Bare.on('exit', async () => {
+goodbye(async () => {
   await swarm.destroy()
   await pear.close()
   await store.close()
 })
 
 Bare.IPC.on('data', (data) => {
-    const string = data.toString()
-    if (string === 'pear:applyUpdate') pear.updater.applyUpdate()
-    else console.log(string)
+  const string = data.toString()
+  if (string === 'pear:applyUpdate') pear.updater.applyUpdate()
+  else console.log(string)
 })
 
 Bare.IPC.write('Hello from worker')

--- a/workers/main.js
+++ b/workers/main.js
@@ -2,9 +2,19 @@ const PearRuntime = require('pear-runtime')
 const Hyperswarm = require('hyperswarm')
 const Corestore = require('corestore')
 const goodbye = require('graceful-goodbye')
+const FramedStream = require('framed-stream')
 const path = require('bare-path')
 
-const updaterConfig = JSON.parse(Bare.argv[2])
+const pipe = new FramedStream(Bare.IPC)
+
+const updaterConfig = {
+  dir: Bare.argv[2],
+  app: Bare.argv[3],
+  updates: Bare.argv[4],
+  version: Bare.argv[5],
+  upgrade: Bare.argv[6],
+  name: Bare.argv[7]
+}
 
 const store = new Corestore(path.join(updaterConfig.dir, 'pear-runtime/corestore'))
 const swarm = new Hyperswarm()
@@ -20,8 +30,8 @@ if (updaterConfig.updates !== false) {
 
 console.log('Application storage:', pear.storage)
 
-pear.updater.on('updating', () => Bare.IPC.write('updating'))
-pear.updater.on('updated', () => Bare.IPC.write('updated'))
+pear.updater.on('updating', () => pipe.write('updating'))
+pear.updater.on('updated', () => pipe.write('updated'))
 
 goodbye(async () => {
   await swarm.destroy()
@@ -29,12 +39,12 @@ goodbye(async () => {
   await store.close()
 })
 
-Bare.IPC.on('data', async (data) => {
+pipe.on('data', async (data) => {
   const message = data.toString()
   if (message === 'pear:applyUpdate') {
     await pear.updater.applyUpdate()
-    Bare.IPC.write('pear:updateApplied')
+    pipe.write('pear:updateApplied')
   } else console.log(message)
 })
 
-Bare.IPC.write('Hello from worker')
+pipe.write('Hello from worker')

--- a/workers/main.js
+++ b/workers/main.js
@@ -18,6 +18,8 @@ if (updaterConfig.updates !== false) {
   })
 }
 
+console.log('Application storage:', pear.storage)
+
 pear.updater.on('updating', () => Bare.IPC.write('updating'))
 pear.updater.on('updated', () => Bare.IPC.write('updated'))
 
@@ -28,12 +30,11 @@ goodbye(async () => {
 })
 
 Bare.IPC.on('data', async (data) => {
-  const string = data.toString()
-  if (string === 'pear:applyUpdate') {
+  const message = data.toString()
+  if (message === 'pear:applyUpdate') {
     await pear.updater.applyUpdate()
     Bare.IPC.write('pear:updateApplied')
-  }
-  else console.log(string)
+  } else console.log(message)
 })
 
 Bare.IPC.write('Hello from worker')

--- a/workers/main.js
+++ b/workers/main.js
@@ -27,9 +27,12 @@ goodbye(async () => {
   await store.close()
 })
 
-Bare.IPC.on('data', (data) => {
+Bare.IPC.on('data', async (data) => {
   const string = data.toString()
-  if (string === 'pear:applyUpdate') pear.updater.applyUpdate()
+  if (string === 'pear:applyUpdate') {
+    await pear.updater.applyUpdate()
+    Bare.IPC.write('pear:updateApplied')
+  }
   else console.log(string)
 })
 

--- a/workers/main.js
+++ b/workers/main.js
@@ -10,7 +10,7 @@ const pipe = new FramedStream(Bare.IPC)
 const updaterConfig = {
   dir: Bare.argv[2],
   app: Bare.argv[3],
-  updates: Bare.argv[4] === 'true',
+  updates: Bare.argv[4] !== 'false',
   version: Bare.argv[5],
   upgrade: Bare.argv[6],
   name: Bare.argv[7]

--- a/workers/main.js
+++ b/workers/main.js
@@ -20,6 +20,12 @@ if (updaterConfig.updates !== false) {
 pear.updater.on('updating', () => Bare.IPC.write('updating'))
 pear.updater.on('updated', () => Bare.IPC.write('updated'))
 
+Bare.on('exit', async () => {
+  await swarm.destroy()
+  await pear.close()
+  await store.close()
+})
+
 Bare.IPC.on('data', (data) => {
     const string = data.toString()
     if (string === 'pear:applyUpdate') pear.updater.applyUpdate()

--- a/workers/main.js
+++ b/workers/main.js
@@ -1,5 +1,29 @@
-Bare.IPC.on('data', (data) => console.log(data.toString()))
+const PearRuntime = require('pear-runtime')
+const Hyperswarm = require('hyperswarm')
+const Corestore = require('corestore')
+const path = require('bare-path')
+
+const updaterConfig = JSON.parse(Bare.argv[2])
+
+const store = new Corestore(path.join(updaterConfig.dir, 'pear-runtime/corestore'))
+const swarm = new Hyperswarm()
+const pear = new PearRuntime({...updaterConfig, swarm, store})
+pear.on('error', console.log)
+if (updaterConfig.updates !== false) {
+  swarm.on('connection', (connection) => store.replicate(connection))
+  swarm.join(pear.updater.drive.core.discoveryKey, {
+    client: true,
+    server: false
+  })
+}
+
+pear.updater.on('updating', () => Bare.IPC.write('updating'))
+pear.updater.on('updated', () => Bare.IPC.write('updated'))
+
+Bare.IPC.on('data', (data) => {
+    const string = data.toString()
+    if (string === 'pear:applyUpdate') pear.updater.applyUpdate()
+    else console.log(string)
+})
 
 Bare.IPC.write('Hello from worker')
-
-console.log('Application storage:', Bare.argv[2])


### PR DESCRIPTION
## Moving pear-runtime updater to bare worker process
- remove any pear-runtime related handlers and logic in electron main and renderer
- handle updates in worker
- forward updates through worker IPC and electron worker IPC
- adjust app handlers for applyUpdate

## Additional Fixes
- call `app.quit()` insted of `app.exit(0)` -> app.quit() will call `app.on('before-quit')` and with that worker destroy before app closes, app.exit() wont
- Fix windows storage path -> app storage is at `Roaming`, not `Local` (see attachment)
<img width="1110" height="545" alt="Screenshot 2026-05-22 000122" src="https://github.com/user-attachments/assets/b65b1cb8-5416-4721-a846-db7497a86019" />
<img width="1114" height="676" alt="Screenshot 2026-05-22 000143" src="https://github.com/user-attachments/assets/55c48d49-9daf-4214-811c-610c0768e727" />

